### PR TITLE
Suggestion : Change icon to paste

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,7 +62,7 @@ const ClipboardIndicator = Lang.Class({
     _init: function() {
         this.parent(0.0, "ClipboardIndicator");
         let hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box clipboard-indicator-hbox' });
-        let icon = new St.Icon({ icon_name: 'edit-cut-symbolic', //'mail-attachment-symbolic',
+        let icon = new St.Icon({ icon_name: 'edit-paste-symbolic', //'mail-attachment-symbolic',
             style_class: 'system-status-icon clipboard-indicator-icon' });
 
         hbox.add_child(icon);


### PR DESCRIPTION
This is really really subjective matter but ... how about using the "paste" icon instead of "cut" on the clipboard indicator ? It's a little closer to the extension job, which is all about what we want to paste, and the paste symbolic icon has a nice clipboard look too. Or maybe the "cut" has some special meaning for you ?

We may also go further and add a preference where one can choose between cut/copy/paste icons. 

Edit :
In case you wonder what is the 'paste' icon, here it is :
![screenshot from 2015-04-25 22-42-31](https://cloud.githubusercontent.com/assets/1675389/7334750/7547e490-eb9c-11e4-8fdb-7dfc95851ce1.png)
