### PR TITLE
menu: put latest element on top

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -163,7 +163,7 @@ const ClipboardIndicator = Lang.Class({
             })
         );
 
-        this.historySection.addMenuItem(menuItem);
+        this.historySection.addMenuItem(menuItem, 0);
 
         if (autoSelect === true)
             this._selectMenuItem(menuItem, autoSetClip);


### PR DESCRIPTION
If you keep a number of commit too large, the menu grows too big and you can see with a click which is the last you have in there. By reverting the order and placing latest elements on top, you fix this situation.