### PR TITLE
Fixes #9: When indicator menu is open, navigate using arrows and select with ENTER

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,12 +105,12 @@ const ClipboardIndicator = Lang.Class({
             // Add 'Clear' button which removes all items from cache
             let clearMenuItem = new PopupMenu.PopupMenuItem(_('Clear history'));
             that.menu.addMenuItem(clearMenuItem);
-            clearMenuItem.actor.connect('button-press-event', Lang.bind(that, that._removeAll));
+            clearMenuItem.connect('activate', Lang.bind(that, that._removeAll));
 
             // Add 'Settings' menu item to open settings
             let settingsMenuItem = new PopupMenu.PopupMenuItem(_('Settings'));
             that.menu.addMenuItem(settingsMenuItem);
-            settingsMenuItem.actor.connect('button-press-event', Lang.bind(that, that._openSettings));
+            settingsMenuItem.connect('activate', Lang.bind(that, that._openSettings));
 
             if (lastIdx >= 0) {
                 that._selectMenuItem(clipItemsArr[lastIdx]);
@@ -131,9 +131,10 @@ const ClipboardIndicator = Lang.Class({
     _addEntry: function (buffer, autoSelect, autoSetClip) {
         let menuItem = new PopupMenu.PopupMenuItem('');
 
+        menuItem.menu = this.menu;
         menuItem.clipContents = buffer;
         menuItem.radioGroup = this.clipItemsRadioGroup;
-        menuItem.buttonPressId = menuItem.actor.connect('button-press-event',
+        menuItem.buttonPressId = menuItem.connect('activate',
             Lang.bind(menuItem, this._onMenuItemSelected));
 
         this._setEntryLabel(menuItem);
@@ -224,6 +225,8 @@ const ClipboardIndicator = Lang.Class({
                 menuItem.currentlySelected = false;
             }
         });
+
+        that.menu.close();
     },
 
     _selectMenuItem: function (menuItem, autoSet) {


### PR DESCRIPTION
I couldn't set focus to a menu item, but if you push UP arrow it will focus on the first item and ENTER works now! If somebody knows how to set focus, please help me or create a pull request, it should be just one line around `extension.js:450`! I've already tried:

```js
this.clipItemsRadioGroup[0].focus();
this.clipItemsRadioGroup[0].emit('focus');
this.clipItemsRadioGroup[0].emit('focus:');
this.clipItemsRadioGroup[0].emit('object:state-changed:focused');
this.clipItemsRadioGroup[0].emit('object:state-changed:focused', true);
...
```

Nothing seems to work :(