### PR TITLE
Fix 'Toggle the menu' function

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -532,11 +532,8 @@ const ClipboardIndicator = Lang.Class({
         });
     },
 
-    _toggleMenu:function(){
-        if(this.menu.visible)
-            this.menu.close();
-        else
-            this.menu.open();
+    _toggleMenu: function(){
+        this.menu.toggle();
     }
 });
 


### PR DESCRIPTION
Update the _toggleMenu function to use .menu.toggle() as the existing menu visibility check does not work.