### PR TITLE
Fix signal handler disconnect

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -214,7 +214,7 @@ const ClipboardIndicator = Lang.Class({
         let that = this;
         while (that.clipItemsRadioGroup.length > MAX_REGISTRY_LENGTH) {
             let oldest = that.clipItemsRadioGroup.shift();
-            oldest.actor.disconnect(oldest.buttonPressId);
+            oldest.disconnect(oldest.buttonPressId);
             oldest.destroy();
         }
 


### PR DESCRIPTION
This fixes the disconnection of the the signal handler when removing old entries which was throwing gsignal instance has no handler with id errors.