### PR TITLE
dont truncate if no content

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -94,8 +94,9 @@ const ClipboardIndicator = Lang.Class({
     _updateButtonText: function(content){
         if (!content || PRIVATEMODE){
             this._buttonText.set_text("...")
+        } else {
+            this._buttonText.set_text(this._truncate(content, MAX_TOPBAR_LENGTH));
         }
-        this._buttonText.set_text(this._truncate(content, MAX_TOPBAR_LENGTH));
     },
 
     _buildMenu: function () {


### PR DESCRIPTION
Correction of this error (at boot time) : 

gnome-shell[6944]: JS ERROR: TypeError: string is null
ClipboardIndicator<._truncate@/home/$$$/.local/share/gnome-shell/extensions/clipboard-indicator@tudmotu.com/extension.js:211:13
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
ClipboardIndicator<._updateButtonText@/home/$$$/.local/share/gnome-shell/extensions/clipboard-indicator@tudmotu.com/extension.js:98:35
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
ClipboardIndicator<._onPrivateModeSwitch/<@/home/$$$/.local/share/gnome-shell/extensions/clipboard-indicator@tudmotu.com/extension.js:460:29