### PR TITLE
Increase maximum history size to 200.

### DIFF
--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -21,7 +21,7 @@
         <default>15</default>
         <summary>The number of items to save in history</summary>
         <description></description>
-        <range min="1" max="50"/>
+        <range min="1" max="200"/>
     </key>
 
     <key type="i" name="display-mode">


### PR DESCRIPTION
This pull request is related to https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator/issues/102.