### PR TITLE
Allow installation for 3.36

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
         "3.28",
         "3.30",
         "3.32",
-        "3.34"
+        "3.34",
+        "3.36"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
_This PR only update the manifest, not tested if needs specific adaptations_

GNOME Shell 3.36 was released but it wasn't possible to install this application on it