### PR TITLE
Use new convenience function to open settings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -553,10 +553,14 @@ const ClipboardIndicator = Lang.Class({
     },
 
     _openSettings: function () {
-        Util.spawn([
-            "gnome-shell-extension-prefs",
-            Me.uuid
-        ]);
+        if (typeof ExtensionUtils.openPrefs === 'function') {
+            ExtensionUtils.openPrefs();
+        } else {
+            Util.spawn([
+                "gnome-shell-extension-prefs",
+                Me.uuid
+            ]);
+        }
     },
 
     _initNotifSource: function () {


### PR DESCRIPTION
GS 3.36 introduced a portal-like API for actions like opening settings.
That was done in order to make it possible to ship the new extensions
app in a sandboxed manner, e.g. via flatpak.

While talking to the API directly is a bit cumbersome, luckily there
is a convenience function we can make use of (from GS 3.36.2 on).

Closes https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator/issues/202

This depends on https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1163 to land first -> ~WIP~ -> MR landed now