### PR TITLE
Able to select item by the keyboard events

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,8 +1,12 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const St = imports.gi.St;
 const FileQueryInfoFlags = imports.gi.Gio.FileQueryInfoFlags;
 const FileCopyFlags = imports.gi.Gio.FileCopyFlags;
 const FileTest = GLib.FileTest;
+
+const Clipboard = St.Clipboard.get_default();
+const CLIPBOARD_TYPE = St.ClipboardType.CLIPBOARD;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -15,7 +19,7 @@ const REGISTRY_PATH = REGISTRY_DIR + '/' + REGISTRY_FILE;
 const BACKUP_REGISTRY_PATH = REGISTRY_PATH + '~';
 
 // Print objects... why no dev tools
-function prettyPrint (name, obj, recurse, _indent) {
+function prettyPrint(name, obj, recurse, _indent) {
     let prefix = '';
     let indent = typeof _indent === 'number' ? _indent : 0;
     for (let i = 0; i < indent; i++) {
@@ -44,7 +48,7 @@ function prettyPrint (name, obj, recurse, _indent) {
 }
 
 // I/O Files
-function writeRegistry (registry) {
+function writeRegistry(registry) {
     let json = JSON.stringify(registry);
     let contents = new GLib.Bytes(json);
 
@@ -54,20 +58,20 @@ function writeRegistry (registry) {
     // Write contents to file asynchronously
     let file = Gio.file_new_for_path(REGISTRY_PATH);
     file.replace_async(null, false, Gio.FileCreateFlags.NONE,
-                        GLib.PRIORITY_DEFAULT, null, function (obj, res) {
+        GLib.PRIORITY_DEFAULT, null, function (obj, res) {
 
-        let stream = obj.replace_finish(res);
+            let stream = obj.replace_finish(res);
 
-        stream.write_bytes_async(contents, GLib.PRIORITY_DEFAULT,
-                            null, function (w_obj, w_res) {
+            stream.write_bytes_async(contents, GLib.PRIORITY_DEFAULT,
+                null, function (w_obj, w_res) {
 
-            w_obj.write_bytes_finish(w_res);
-            stream.close(null);
+                    w_obj.write_bytes_finish(w_res);
+                    stream.close(null);
+                });
         });
-    });
 }
 
-function readRegistry (callback) {
+function readRegistry(callback) {
     if (typeof callback !== 'function')
         throw TypeError('`callback` must be a function');
 
@@ -76,59 +80,68 @@ function readRegistry (callback) {
         let CACHE_FILE_SIZE = SettingsSchema.get_int(Prefs.Fields.CACHE_FILE_SIZE);
 
         file.query_info_async('*', FileQueryInfoFlags.NONE,
-                              GLib.PRIORITY_DEFAULT, null, function (src, res) {
-            // Check if file size is larger than CACHE_FILE_SIZE
-            // If so, make a backup of file, and invoke callback with empty array
-            let file_info = src.query_info_finish(res);
+            GLib.PRIORITY_DEFAULT, null, function (src, res) {
+                // Check if file size is larger than CACHE_FILE_SIZE
+                // If so, make a backup of file, and invoke callback with empty array
+                let file_info = src.query_info_finish(res);
 
-            if (file_info.get_size() >= CACHE_FILE_SIZE * 1024) {
-                let destination = Gio.file_new_for_path(BACKUP_REGISTRY_PATH);
+                if (file_info.get_size() >= CACHE_FILE_SIZE * 1024) {
+                    let destination = Gio.file_new_for_path(BACKUP_REGISTRY_PATH);
 
-                file.move(destination, FileCopyFlags.OVERWRITE, null, null);
-                callback([]);
-                return;
-            }
+                    file.move(destination, FileCopyFlags.OVERWRITE, null, null);
+                    callback([]);
+                    return;
+                }
 
-            file.load_contents_async(null, function (obj, res) {
-                let registry;
-                let [success, contents] = obj.load_contents_finish(res);
+                file.load_contents_async(null, function (obj, res) {
+                    let registry;
+                    let [success, contents] = obj.load_contents_finish(res);
 
-                if (success) {
-                    try {
-                        let max_size = SettingsSchema.get_int(Prefs.Fields.HISTORY_SIZE);
+                    if (success) {
+                        try {
+                            let max_size = SettingsSchema.get_int(Prefs.Fields.HISTORY_SIZE);
 
-                        // are we running gnome 3.30 or higher?
-                        if (contents instanceof Uint8Array) {
-                          contents = imports.byteArray.toString(contents);
+                            // are we running gnome 3.30 or higher?
+                            if (contents instanceof Uint8Array) {
+                                contents = imports.byteArray.toString(contents);
+                            }
+
+                            registry = JSON.parse(contents);
+
+                            let registryNoFavorite = registry.filter(
+                                item => item['favorite'] === false);
+
+                            while (registryNoFavorite.length > max_size) {
+                                let oldestNoFavorite = registryNoFavorite.shift();
+                                let itemIdx = registry.indexOf(oldestNoFavorite);
+                                registry.splice(itemIdx, 1);
+
+                                registryNoFavorite = registry.filter(
+                                    item => item["favorite"] === false);
+                            }
                         }
-
-                        registry = JSON.parse(contents);
-
-                        let registryNoFavorite = registry.filter(
-                            item => item['favorite'] === false);
-
-                        while (registryNoFavorite.length > max_size) {
-                            let oldestNoFavorite = registryNoFavorite.shift();
-                            let itemIdx = registry.indexOf(oldestNoFavorite);
-                            registry.splice(itemIdx,1);
-
-                            registryNoFavorite = registry.filter(
-                                item => item["favorite"] === false);
+                        catch (e) {
+                            registry = [];
                         }
                     }
-                    catch (e) {
+                    else {
                         registry = [];
                     }
-                }
-                else {
-                    registry = [];
-                }
 
-                callback(registry);
+                    callback(registry);
+                });
             });
-        });
     }
     else {
         callback([]);
     }
+}
+
+function getClipboardText(fn) {
+    Clipboard.get_text(CLIPBOARD_TYPE, fn);
+}
+
+function setClipboardText(content) {
+    //log("Clipboard set to: '" + content + "'");
+    Clipboard.set_text(CLIPBOARD_TYPE, content);
 }


### PR DESCRIPTION
Fixing #156.

Please test it before merge. I brought out the Set ad Get clipboard functions to Utils for ease of debugging.
The `activate` event worked fine. The problem was inside `_onMenuItemSelected` which was duplicated with `_onMenuItemSelectedAndMenuClose`.

