### PR TITLE
Gnome 3.38 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -85,7 +85,7 @@ const ClipboardIndicator = Lang.Class({
         });
         hbox.add_child(this._buttonText);
         hbox.add(PopupMenu.arrowIcon(St.Side.BOTTOM));
-        this.actor.add_child(hbox);
+        this.add_child(hbox);
 
         this._createHistoryLabel();
         this._loadSettings();
@@ -122,7 +122,9 @@ const ClipboardIndicator = Lang.Class({
                 style_class: 'search-entry',
                 can_focus: true,
                 hint_text: _('Type here to search...'),
-                track_hover: true
+                track_hover: true,
+                x_expand: true,
+                y_expand: true
             });
 
             that.searchEntry.get_clutter_text().connect(
@@ -130,7 +132,7 @@ const ClipboardIndicator = Lang.Class({
                 Lang.bind(that, that._onSearchTextChanged)
             );
 
-            that._entryItem.actor.add(that.searchEntry, { expand: true });
+            that._entryItem.add(that.searchEntry);
 
             that.menu.addMenuItem(that._entryItem);
 
@@ -268,14 +270,12 @@ const ClipboardIndicator = Lang.Class({
 
         let icofavBtn = new St.Button({
             style_class: 'ci-action-btn',
-            x_fill: true,
             can_focus: true,
-            child: iconfav
+            child: iconfav,
+            x_align: Clutter.ActorAlign.END,
+            x_expand: true,
+            y_expand: true
         });
-
-        icofavBtn.set_x_align(Clutter.ActorAlign.END);
-        icofavBtn.set_x_expand(true);
-        icofavBtn.set_y_expand(true);
 
         menuItem.actor.add_child(icofavBtn);
         menuItem.icofavBtn = icofavBtn;
@@ -293,14 +293,12 @@ const ClipboardIndicator = Lang.Class({
 
         let icoBtn = new St.Button({
             style_class: 'ci-action-btn',
-            x_fill: true,
             can_focus: true,
-            child: icon
+            child: icon,
+            x_align: Clutter.ActorAlign.END,
+            x_expand: false,
+            y_expand: true
         });
-
-        icoBtn.set_x_align(Clutter.ActorAlign.END);
-        icoBtn.set_x_expand(false);
-        icoBtn.set_y_expand(true);
 
         menuItem.actor.add_child(icoBtn);
         menuItem.icoBtn = icoBtn;

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,7 @@
 {
     "shell-version": [
-        "3.24",
-        "3.26",
-        "3.28",
-        "3.30",
-        "3.32",
-        "3.34",
-        "3.36"
+        "3.36",
+        "3.38"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
 - remove deprecated this.actor usage
 - remove deprecated x_fill usage
 - set more properties in constructors
 - use `x_expand`/`y_expand`
 - remove pre-3.36 support

Closes #230, closes #228, closes #192