### PR TITLE
Add toggle for confirmation on clear history

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -45,6 +45,7 @@ let MOVE_ITEM_FIRST      = false;
 let ENABLE_KEYBINDING    = true;
 let PRIVATEMODE          = false;
 let NOTIFY_ON_COPY       = true;
+let CONFIRM_ON_CLEAR     = true;
 let MAX_TOPBAR_LENGTH    = 15;
 let TOPBAR_DISPLAY_MODE  = 1; //0 - only icon, 1 - only clipbord content, 2 - both
 let DISABLE_DOWN_ARROW   = false;
@@ -335,27 +336,43 @@ const ClipboardIndicator = Lang.Class({
 
         this._updateCache();
     },
-    _removeAll: function () {
+  
+    _confirmRemoveAll: function () {
         const title = _("Clear all?");
         const message = _("Are you sure you want to delete all clipboard items?");
         const sub_message = _("This operation cannot be undone.");
 
-        ConfirmDialog.openConfirmDialog(title, message, sub_message, _("Clear"), _("Cancel"), () => {;
+        ConfirmDialog.openConfirmDialog(title, message, sub_message, _("Clear"), _("Cancel"), () => {
             let that = this;
-            // We can't actually remove all items, because the clipboard still
-            // has data that will be re-captured on next refresh, so we remove
-            // all except the currently selected item
-            // Don't remove favorites here
-            that.historySection._getMenuItems().forEach(function (mItem) {
-                if (!mItem.currentlySelected) {
-                    let idx = that.clipItemsRadioGroup.indexOf(mItem);
-                    mItem.destroy();
-                    that.clipItemsRadioGroup.splice(idx,1);
-                }
-            });
-            that._updateCache();
-            that._showNotification(_("Clipboard history cleared"));
+            that._clearHistory();
+        }
+      );
+    },
+
+    _clearHistory: function () {
+        let that = this;
+        // We can't actually remove all items, because the clipboard still
+        // has data that will be re-captured on next refresh, so we remove
+        // all except the currently selected item
+        // Don't remove favorites here
+        that.historySection._getMenuItems().forEach(function (mItem) {
+            if (!mItem.currentlySelected) {
+                let idx = that.clipItemsRadioGroup.indexOf(mItem);
+                mItem.destroy();
+                that.clipItemsRadioGroup.splice(idx, 1);
+            }
         });
+        that._updateCache();
+        that._showNotification(_("Clipboard history cleared"));    },
+
+    _removeAll: function () {
+        var that = this;
+
+        if (CONFIRM_ON_CLEAR) {
+            that._confirmRemoveAll();
+        } else {
+            that._clearHistory();
+        }
     },
 
     _removeEntry: function (menuItem, event) {
@@ -677,6 +694,7 @@ const ClipboardIndicator = Lang.Class({
         DELETE_ENABLED       = this._settings.get_boolean(Prefs.Fields.DELETE);
         MOVE_ITEM_FIRST      = this._settings.get_boolean(Prefs.Fields.MOVE_ITEM_FIRST);
         NOTIFY_ON_COPY       = this._settings.get_boolean(Prefs.Fields.NOTIFY_ON_COPY);
+        CONFIRM_ON_CLEAR     = this._settings.get_boolean(Prefs.Fields.CONFIRM_ON_CLEAR);
         ENABLE_KEYBINDING    = this._settings.get_boolean(Prefs.Fields.ENABLE_KEYBINDING);
         MAX_TOPBAR_LENGTH    = this._settings.get_int(Prefs.Fields.TOPBAR_PREVIEW_SIZE);
         TOPBAR_DISPLAY_MODE  = this._settings.get_int(Prefs.Fields.TOPBAR_DISPLAY_MODE_ID);

--- a/prefs.js
+++ b/prefs.js
@@ -17,6 +17,7 @@ var Fields = {
     CACHE_ONLY_FAVORITE    : 'cache-only-favorites',
     DELETE                 : 'enable-deletion',
     NOTIFY_ON_COPY         : 'notify-on-copy',
+    CONFIRM_ON_CLEAR       : 'confirm-clear',
     MOVE_ITEM_FIRST        : 'move-item-first',
     ENABLE_KEYBINDING      : 'enable-keybindings',
     TOPBAR_PREVIEW_SIZE    : 'topbar-preview-size',
@@ -98,6 +99,7 @@ const App = new Lang.Class({
         this.field_disable_down_arrow = new Gtk.Switch();
         this.field_cache_disable = new Gtk.Switch();
         this.field_notification_toggle = new Gtk.Switch();
+        this.field_confirm_clear_toggle = new Gtk.Switch();
         this.field_strip_text = new Gtk.Switch();
         this.field_move_item_first = new Gtk.Switch();
         this.field_keybinding = createKeybindingWidget(SettingsSchema);
@@ -143,6 +145,11 @@ const App = new Lang.Class({
         });
         let notificationLabel  = new Gtk.Label({
             label: _("Show notification on copy"),
+            hexpand: true,
+            halign: Gtk.Align.START
+        });
+        let confirmClearLabel = new Gtk.Label({
+            label: _("Show confirmation on Clear History"),
             hexpand: true,
             halign: Gtk.Align.START
         });
@@ -205,6 +212,7 @@ const App = new Lang.Class({
         addRow(cacheSizeLabel,        this.field_cache_size);
         addRow(cacheDisableLabel,     this.field_cache_disable);
         addRow(notificationLabel,     this.field_notification_toggle);
+        addRow(confirmClearLabel,     this.field_confirm_clear_toggle);
         addRow(displayModeLabel,      this.field_display_mode);
         addRow(disableDownArrowLabel, this.field_disable_down_arrow);
         addRow(topbarPreviewLabel,    this.field_topbar_preview_size);
@@ -219,6 +227,7 @@ const App = new Lang.Class({
         SettingsSchema.bind(Fields.CACHE_FILE_SIZE, this.field_cache_size, 'value', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.CACHE_ONLY_FAVORITE, this.field_cache_disable, 'active', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.NOTIFY_ON_COPY, this.field_notification_toggle, 'active', Gio.SettingsBindFlags.DEFAULT);
+        SettingsSchema.bind(Fields.CONFIRM_ON_CLEAR, this.field_confirm_clear_toggle, 'active', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.MOVE_ITEM_FIRST, this.field_move_item_first, 'active', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.TOPBAR_DISPLAY_MODE_ID, this.field_display_mode, 'active', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.DISABLE_DOWN_ARROW, this.field_disable_down_arrow, 'active', Gio.SettingsBindFlags.DEFAULT);

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -81,6 +81,15 @@
             If true, a notification is shown when content is copied to clipboard.
         </description>
     </key>
+
+    <key name="confirm-clear" type="b">
+      <default>true</default>
+        <summary>Show confirmation dialog on Clear History</summary>
+        <description>
+            If true, a confirmation dialog is shown when attempting to Clear History.
+        </description>
+    </key>
+    
     <key name="strip-text" type="b">
       <default>false</default>
       <summary>Remove whitespace around text</summary>


### PR DESCRIPTION
There is currently no option for disabling the confirmation dialog when clearing the history.
This adds a toggle in the settings for enabling/disabling the confirmation dialog.