### PR TITLE
update topbar preview on selection from menu

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -409,6 +409,9 @@ const ClipboardIndicator = Lang.Class({
     _selectMenuItem: function (menuItem, autoSet) {
         let fn = Lang.bind(menuItem, this._onMenuItemSelected);
         fn(autoSet);
+        if(TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
+            this._updateButtonText(menuItem.label.text);
+        }
     },
 
     _onMenuItemSelectedAndMenuClose: function (autoSet) {


### PR DESCRIPTION
Hey @Tudmotu, thanks for the amazing tool, I do not know how I can work without it! 
This fixes #210, and updates the preview in the following cases which were not there earlier:

- When the extension is restarted
- Previous or next content selected through keyboard bindings
- Another selection is made through the dropdown menu

Tested locally. Let me know if you need anything else.