### PR TITLE
Gnome Shell 40 Port

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -90,7 +90,7 @@ const ClipboardIndicator = Lang.Class({
         hbox.add_child(this._buttonText);
         this._downArrow = PopupMenu.arrowIcon(St.Side.BOTTOM);
         hbox.add(this._downArrow);
-        this.actor.add_child(hbox);
+        this.add_child(hbox);
 
         this._createHistoryLabel();
         this._loadSettings();

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "shell-version": [
-        "40.0"
+        "40"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "shell-version": [
-        "3.38"
+        "40.0"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",

--- a/prefs.js
+++ b/prefs.js
@@ -48,7 +48,10 @@ const App = new Lang.Class({
     Name: 'ClipboardIndicator.App',
     _init: function() {
         this.main = new Gtk.Grid({
-            margin: 10,
+            margin_top: 10,
+            margin_bottom: 10,
+            margin_start: 10,
+            margin_end: 10,
             row_spacing: 12,
             column_spacing: 18,
             column_homogeneous: false,
@@ -183,8 +186,8 @@ const App = new Lang.Class({
                 let inputWidget = input;
 
                 if (input instanceof Gtk.Switch) {
-                    inputWidget = new Gtk.HBox();
-                    inputWidget.pack_end(input, false, false, 0);
+                    inputWidget = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,});
+                    inputWidget.append(input);
                 }
 
                 if (label) {
@@ -225,8 +228,6 @@ const App = new Lang.Class({
         SettingsSchema.bind(Fields.TOPBAR_PREVIEW_SIZE, this.field_topbar_preview_size, 'value', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.STRIP_TEXT, this.field_strip_text, 'active', Gio.SettingsBindFlags.DEFAULT);
         SettingsSchema.bind(Fields.ENABLE_KEYBINDING, this.field_keybinding_activation, 'active', Gio.SettingsBindFlags.DEFAULT);
-
-        this.main.show_all();
     },
     _create_display_mode_options : function(){
         let options = [{ name: _("Icon") },

--- a/prefs.js
+++ b/prefs.js
@@ -265,7 +265,7 @@ function addKeybinding(model, settings, id, description) {
     if (accelerator == null)
         [key, mods] = [0, 0];
     else
-        [key, mods] = Gtk.accelerator_parse(settings.get_strv(id)[0]);
+        [,key, mods] = Gtk.accelerator_parse(settings.get_strv(id)[0]);
 
     // Add a row for the keybinding.
     let row = model.insert(100); // Erm...

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -31,7 +31,7 @@
     </key>
 
     <key name="disable-down-arrow" type="b">
-      <default>false</default>
+      <default>true</default>
         <summary>Remove down arrow in top bar</summary>
     </key>
 


### PR DESCRIPTION
**extension.js**

Removed the deprecated actor for ClipboardIndicator.

**prefs.js**

- _Gtk.accelerator_parse()_ now returns first element as ok.
- _show_all()_ no longer works and needed on GTK4.
- Instead of _HBox_ use Gtk.Box.
- _margin_ no longer supported in GTK4 and replaced with more detailed margin properties.

**metadata.json**

Removed "3.38" and added "40.0" to the shell version.