### PR TITLE
Do not create notification when history is cleared

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -363,7 +363,7 @@ const ClipboardIndicator = Lang.Class({
             }
         });
         that._updateCache();
-        that._showNotification(_("Clipboard history cleared"));    },
+    },
 
     _removeAll: function () {
         var that = this;


### PR DESCRIPTION
Since the user is actively choosing to clear the history, the subsequent notification is redundant.
On my system I have to actively cancel the notification, which is quite annoying.