### PR TITLE
build: support for gnome 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
     "shell-version": [
-        "40"
+        "40",
+        "41"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
On updating to Fedora 35 which has gnome 41, the extension didn't work. This contribution allows the extension to work on gnome 41 too.