### PR TITLE
Use consistent style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI/CD
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          cache: 'npm'
+      - name: Check style
+        run: npx prettier --check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.zip
+.idea
+node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/confirmDialog.js
+++ b/confirmDialog.js
@@ -6,38 +6,51 @@ const Clutter = imports.gi.Clutter;
 
 let _openDialog;
 
-function openConfirmDialog(title, message, sub_message, ok_label, cancel_label, callback) {
-  if (!_openDialog)
-    _openDialog = new ConfirmDialog(title, message + "\n" + sub_message, ok_label, cancel_label, callback).open();
+function openConfirmDialog(
+  title,
+  message,
+  sub_message,
+  ok_label,
+  cancel_label,
+  callback,
+) {
+  if (!_openDialog) {
+    _openDialog = new ConfirmDialog(
+      title,
+      message + '\n' + sub_message,
+      ok_label,
+      cancel_label,
+      callback,
+    ).open();
+  }
 }
 
 const ConfirmDialog = GObject.registerClass(
   class ConfirmDialog extends ModalDialog.ModalDialog {
-
     _init(title, desc, ok_label, cancel_label, callback) {
       super._init();
 
       let main_box = new St.BoxLayout({
-        vertical: false
+        vertical: false,
       });
       this.contentLayout.add_child(main_box);
 
       let message_box = new St.BoxLayout({
-        vertical: true
+        vertical: true,
       });
       main_box.add_child(message_box);
 
       let subject_label = new St.Label({
         style: 'font-weight: bold',
         x_align: Clutter.ActorAlign.CENTER,
-        text: title
+        text: title,
       });
       message_box.add_child(subject_label);
 
       let desc_label = new St.Label({
         style: 'padding-top: 12px',
         x_align: Clutter.ActorAlign.CENTER,
-        text: desc
+        text: desc,
       });
       message_box.add_child(desc_label);
 
@@ -48,7 +61,7 @@ const ConfirmDialog = GObject.registerClass(
             this.close();
             _openDialog = null;
           },
-          key: Clutter.Escape
+          key: Clutter.Escape,
         },
         {
           label: ok_label,
@@ -56,9 +69,9 @@ const ConfirmDialog = GObject.registerClass(
             this.close();
             callback();
             _openDialog = null;
-          }
-        }
+          },
+        },
       ]);
     }
-  }
+  },
 );

--- a/extension.js
+++ b/extension.js
@@ -1,19 +1,19 @@
-const Clutter    = imports.gi.Clutter;
-const Config     = imports.misc.config;
-const Gio        = imports.gi.Gio;
-const Lang       = imports.lang;
-const Mainloop   = imports.mainloop;
-const Meta       = imports.gi.Meta;
-const Shell      = imports.gi.Shell;
-const St         = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+const Config = imports.misc.config;
+const Gio = imports.gi.Gio;
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
+const Meta = imports.gi.Meta;
+const Shell = imports.gi.Shell;
+const St = imports.gi.St;
 const PolicyType = imports.gi.Gtk.PolicyType;
-const Util       = imports.misc.util;
+const Util = imports.misc.util;
 const MessageTray = imports.ui.messageTray;
 
-const Main      = imports.ui.main;
+const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
-const CheckBox  = imports.ui.checkBox.CheckBox;
+const CheckBox = imports.ui.checkBox.CheckBox;
 
 const Gettext = imports.gettext;
 const _ = Gettext.domain('clipboard-indicator').gettext;
@@ -21,10 +21,10 @@ const _ = Gettext.domain('clipboard-indicator').gettext;
 const Clipboard = St.Clipboard.get_default();
 const CLIPBOARD_TYPE = St.ClipboardType.CLIPBOARD;
 
-const SETTING_KEY_CLEAR_HISTORY = "clear-history";
-const SETTING_KEY_PREV_ENTRY = "prev-entry";
-const SETTING_KEY_NEXT_ENTRY = "next-entry";
-const SETTING_KEY_TOGGLE_MENU = "toggle-menu";
+const SETTING_KEY_CLEAR_HISTORY = 'clear-history';
+const SETTING_KEY_PREV_ENTRY = 'prev-entry';
+const SETTING_KEY_NEXT_ENTRY = 'next-entry';
+const SETTING_KEY_TOGGLE_MENU = 'toggle-menu';
 const INDICATOR_ICON = 'edit-paste-symbolic';
 
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -36,869 +36,942 @@ const prettyPrint = Utils.prettyPrint;
 const writeRegistry = Utils.writeRegistry;
 const readRegistry = Utils.readRegistry;
 
-let TIMEOUT_MS           = 1000;
-let MAX_REGISTRY_LENGTH  = 15;
-let MAX_ENTRY_LENGTH     = 50;
-let CACHE_ONLY_FAVORITE  = false;
-let DELETE_ENABLED       = true;
-let MOVE_ITEM_FIRST      = false;
-let ENABLE_KEYBINDING    = true;
-let PRIVATEMODE          = false;
-let NOTIFY_ON_COPY       = true;
-let CONFIRM_ON_CLEAR     = true;
-let MAX_TOPBAR_LENGTH    = 15;
-let TOPBAR_DISPLAY_MODE  = 1; //0 - only icon, 1 - only clipbord content, 2 - both
-let DISABLE_DOWN_ARROW   = false;
-let STRIP_TEXT           = false;
+let TIMEOUT_MS = 1000;
+let MAX_REGISTRY_LENGTH = 15;
+let MAX_ENTRY_LENGTH = 50;
+let CACHE_ONLY_FAVORITE = false;
+let DELETE_ENABLED = true;
+let MOVE_ITEM_FIRST = false;
+let ENABLE_KEYBINDING = true;
+let PRIVATEMODE = false;
+let NOTIFY_ON_COPY = true;
+let CONFIRM_ON_CLEAR = true;
+let MAX_TOPBAR_LENGTH = 15;
+let TOPBAR_DISPLAY_MODE = 1; //0 - only icon, 1 - only clipbord content, 2 - both
+let DISABLE_DOWN_ARROW = false;
+let STRIP_TEXT = false;
 
 const ClipboardIndicator = Lang.Class({
-    Name: 'ClipboardIndicator',
-    Extends: PanelMenu.Button,
+  Name: 'ClipboardIndicator',
+  Extends: PanelMenu.Button,
 
-    _settingsChangedId: null,
-    _clipboardTimeoutId: null,
-    _selectionOwnerChangedId: null,
-    _historyLabelTimeoutId: null,
-    _historyLabel: null,
-    _buttonText: null,
-    _disableDownArrow: null,
+  _settingsChangedId: null,
+  _clipboardTimeoutId: null,
+  _selectionOwnerChangedId: null,
+  _historyLabelTimeoutId: null,
+  _historyLabel: null,
+  _buttonText: null,
+  _disableDownArrow: null,
 
-    destroy: function () {
-        this._disconnectSettings();
-        this._unbindShortcuts();
-        this._clearClipboardTimeout();
-        this._disconnectSelectionListener();
-        this._clearLabelTimeout();
-        this._clearDelayedSelectionTimeout();
+  destroy: function () {
+    this._disconnectSettings();
+    this._unbindShortcuts();
+    this._clearClipboardTimeout();
+    this._disconnectSelectionListener();
+    this._clearLabelTimeout();
+    this._clearDelayedSelectionTimeout();
 
-        // Call parent
-        this.parent();
-    },
+    // Call parent
+    this.parent();
+  },
 
-    _init: function() {
-        this.parent(0.0, "ClipboardIndicator");
-        this._shortcutsBindingIds = [];
-        this.clipItemsRadioGroup = [];
+  _init: function () {
+    this.parent(0.0, 'ClipboardIndicator');
+    this._shortcutsBindingIds = [];
+    this.clipItemsRadioGroup = [];
 
-        let hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box clipboard-indicator-hbox' });
-        this.icon = new St.Icon({ icon_name: INDICATOR_ICON,
-            style_class: 'system-status-icon clipboard-indicator-icon' });
-        hbox.add_child(this.icon);
-        this._buttonText = new St.Label({
-            text: _('Text will be here'),
-            y_align: Clutter.ActorAlign.CENTER
-        });
-        hbox.add_child(this._buttonText);
-        this._downArrow = PopupMenu.arrowIcon(St.Side.BOTTOM);
-        hbox.add(this._downArrow);
-        this.add_child(hbox);
+    let hbox = new St.BoxLayout({
+      style_class: 'panel-status-menu-box clipboard-indicator-hbox',
+    });
+    this.icon = new St.Icon({
+      icon_name: INDICATOR_ICON,
+      style_class: 'system-status-icon clipboard-indicator-icon',
+    });
+    hbox.add_child(this.icon);
+    this._buttonText = new St.Label({
+      text: _('Text will be here'),
+      y_align: Clutter.ActorAlign.CENTER,
+    });
+    hbox.add_child(this._buttonText);
+    this._downArrow = PopupMenu.arrowIcon(St.Side.BOTTOM);
+    hbox.add(this._downArrow);
+    this.add_child(hbox);
 
-        this._createHistoryLabel();
-        this._loadSettings();
-        this._buildMenu();
+    this._createHistoryLabel();
+    this._loadSettings();
+    this._buildMenu();
 
-        this._updateTopbarLayout();
+    this._updateTopbarLayout();
 
-        this._setupListener();
-    },
-    _updateButtonText: function(content){
-        if (!content || PRIVATEMODE){
-            this._buttonText.set_text("...")
-        } else {
-            this._buttonText.set_text(this._truncate(content, MAX_TOPBAR_LENGTH));
-        }
-    },
+    this._setupListener();
+  },
+  _updateButtonText: function (content) {
+    if (!content || PRIVATEMODE) {
+      this._buttonText.set_text('...');
+    } else {
+      this._buttonText.set_text(this._truncate(content, MAX_TOPBAR_LENGTH));
+    }
+  },
 
-    _buildMenu: function () {
-        let that = this;
-        this._getCache(function (clipHistory) {
-            let lastIdx = clipHistory.length - 1;
-            let clipItemsArr = that.clipItemsRadioGroup;
+  _buildMenu: function () {
+    let that = this;
+    this._getCache(function (clipHistory) {
+      let lastIdx = clipHistory.length - 1;
+      let clipItemsArr = that.clipItemsRadioGroup;
 
-            /* This create the search entry, which is add to a menuItem.
+      /* This create the search entry, which is add to a menuItem.
             The searchEntry is connected to the function for research.
             The menu itself is connected to some shitty hack in order to
             grab the focus of the keyboard. */
-            that._entryItem = new PopupMenu.PopupBaseMenuItem({
-                reactive: false,
-                can_focus: false
-            });
-            that.searchEntry = new St.Entry({
-                name: 'searchEntry',
-                style_class: 'search-entry',
-                can_focus: true,
-                hint_text: _('Type here to search...'),
-                track_hover: true,
-                x_expand: true,
-                y_expand: true
-            });
+      that._entryItem = new PopupMenu.PopupBaseMenuItem({
+        reactive: false,
+        can_focus: false,
+      });
+      that.searchEntry = new St.Entry({
+        name: 'searchEntry',
+        style_class: 'search-entry',
+        can_focus: true,
+        hint_text: _('Type here to search...'),
+        track_hover: true,
+        x_expand: true,
+        y_expand: true,
+      });
 
-            that.searchEntry.get_clutter_text().connect(
-                'text-changed',
-                Lang.bind(that, that._onSearchTextChanged)
-            );
+      that.searchEntry
+        .get_clutter_text()
+        .connect('text-changed', Lang.bind(that, that._onSearchTextChanged));
 
-            that._entryItem.add(that.searchEntry);
+      that._entryItem.add(that.searchEntry);
 
-            that.menu.addMenuItem(that._entryItem);
+      that.menu.addMenuItem(that._entryItem);
 
-            that.menu.connect('open-state-changed', Lang.bind(this, function(self, open){
-                let a = Mainloop.timeout_add(50, Lang.bind(this, function() {
-                    if (open) {
-                        that.searchEntry.set_text('');
-                        global.stage.set_key_focus(that.searchEntry);
-                    }
-                    Mainloop.source_remove(a);
-                }));
-            }));
+      that.menu.connect(
+        'open-state-changed',
+        Lang.bind(this, function (self, open) {
+          let a = Mainloop.timeout_add(
+            50,
+            Lang.bind(this, function () {
+              if (open) {
+                that.searchEntry.set_text('');
+                global.stage.set_key_focus(that.searchEntry);
+              }
+              Mainloop.source_remove(a);
+            }),
+          );
+        }),
+      );
 
-            // Create menu sections for items
-            // Favorites
-            that.favoritesSection = new PopupMenu.PopupMenuSection();
+      // Create menu sections for items
+      // Favorites
+      that.favoritesSection = new PopupMenu.PopupMenuSection();
 
-            that.scrollViewFavoritesMenuSection = new PopupMenu.PopupMenuSection();
-            let favoritesScrollView = new St.ScrollView({
-                style_class: 'ci-history-menu-section',
-                overlay_scrollbars: true
-            });
-            favoritesScrollView.add_actor(that.favoritesSection.actor);
+      that.scrollViewFavoritesMenuSection = new PopupMenu.PopupMenuSection();
+      let favoritesScrollView = new St.ScrollView({
+        style_class: 'ci-history-menu-section',
+        overlay_scrollbars: true,
+      });
+      favoritesScrollView.add_actor(that.favoritesSection.actor);
 
-            that.scrollViewFavoritesMenuSection.actor.add_actor(favoritesScrollView);
-            that.menu.addMenuItem(that.scrollViewFavoritesMenuSection);
-            that.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+      that.scrollViewFavoritesMenuSection.actor.add_actor(favoritesScrollView);
+      that.menu.addMenuItem(that.scrollViewFavoritesMenuSection);
+      that.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            // History
-            that.historySection = new PopupMenu.PopupMenuSection();
+      // History
+      that.historySection = new PopupMenu.PopupMenuSection();
 
-            that.scrollViewMenuSection = new PopupMenu.PopupMenuSection();
-            let historyScrollView = new St.ScrollView({
-                style_class: 'ci-history-menu-section',
-                overlay_scrollbars: true
-            });
-            historyScrollView.add_actor(that.historySection.actor);
+      that.scrollViewMenuSection = new PopupMenu.PopupMenuSection();
+      let historyScrollView = new St.ScrollView({
+        style_class: 'ci-history-menu-section',
+        overlay_scrollbars: true,
+      });
+      historyScrollView.add_actor(that.historySection.actor);
 
-            that.scrollViewMenuSection.actor.add_actor(historyScrollView);
+      that.scrollViewMenuSection.actor.add_actor(historyScrollView);
 
-            that.menu.addMenuItem(that.scrollViewMenuSection);
+      that.menu.addMenuItem(that.scrollViewMenuSection);
 
-            // Add cached items
-            clipHistory.forEach(function (buffer) {
-                if (typeof buffer === 'string') {
-                    // Old cache format
-                    that._addEntry(buffer);
-                } else {
-                    that._addEntry(buffer["contents"], buffer["favorite"]);
-                }
-            });
+      // Add cached items
+      clipHistory.forEach(function (buffer) {
+        if (typeof buffer === 'string') {
+          // Old cache format
+          that._addEntry(buffer);
+        } else {
+          that._addEntry(buffer['contents'], buffer['favorite']);
+        }
+      });
 
-            // Add separator
-            that.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+      // Add separator
+      that.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            // Private mode switch
-            that.privateModeMenuItem = new PopupMenu.PopupSwitchMenuItem(
-                _("Private mode"), PRIVATEMODE, { reactive: true });
-            that.privateModeMenuItem.connect('toggled',
-                Lang.bind(that, that._onPrivateModeSwitch));
-            that.menu.addMenuItem(that.privateModeMenuItem);
-            that._onPrivateModeSwitch();
+      // Private mode switch
+      that.privateModeMenuItem = new PopupMenu.PopupSwitchMenuItem(
+        _('Private mode'),
+        PRIVATEMODE,
+        { reactive: true },
+      );
+      that.privateModeMenuItem.connect(
+        'toggled',
+        Lang.bind(that, that._onPrivateModeSwitch),
+      );
+      that.menu.addMenuItem(that.privateModeMenuItem);
+      that._onPrivateModeSwitch();
 
-            // Add 'Clear' button which removes all items from cache
-            let clearMenuItem = new PopupMenu.PopupMenuItem(_('Clear history'));
-            that.menu.addMenuItem(clearMenuItem);
-            clearMenuItem.connect('activate', Lang.bind(that, that._removeAll));
+      // Add 'Clear' button which removes all items from cache
+      let clearMenuItem = new PopupMenu.PopupMenuItem(_('Clear history'));
+      that.menu.addMenuItem(clearMenuItem);
+      clearMenuItem.connect('activate', Lang.bind(that, that._removeAll));
 
-            // Add 'Settings' menu item to open settings
-            let settingsMenuItem = new PopupMenu.PopupMenuItem(_('Settings'));
-            that.menu.addMenuItem(settingsMenuItem);
-            settingsMenuItem.connect('activate', Lang.bind(that, that._openSettings));
+      // Add 'Settings' menu item to open settings
+      let settingsMenuItem = new PopupMenu.PopupMenuItem(_('Settings'));
+      that.menu.addMenuItem(settingsMenuItem);
+      settingsMenuItem.connect('activate', Lang.bind(that, that._openSettings));
 
-            if (lastIdx >= 0) {
-                that._selectMenuItem(clipItemsArr[lastIdx]);
-            }
-        });
-    },
+      if (lastIdx >= 0) {
+        that._selectMenuItem(clipItemsArr[lastIdx]);
+      }
+    });
+  },
 
-    /* When text change, this function will check, for each item of the
+  /* When text change, this function will check, for each item of the
     historySection and favoritesSestion, if it should be visible or not (based on words contained
     in the clipContents attribute of the item). It doesn't destroy or create
     items. It the entry is empty, the section is restored with all items
     set as visible. */
-    _onSearchTextChanged: function() {
-        let searchedText = this.searchEntry.get_text().toLowerCase();
-
-        if(searchedText === '') {
-            this._getAllIMenuItems().forEach(function(mItem){
-                mItem.actor.visible = true;
-            });
-        }
-        else {
-            this._getAllIMenuItems().forEach(function(mItem){
-                let text = mItem.clipContents.toLowerCase();
-                let isMatching = text.indexOf(searchedText) >= 0;
-                mItem.actor.visible = isMatching
-            });
-        }
-    },
-
-    _truncate: function(string, length) {
-        let shortened = string.replace(/\s+/g, ' ');
-
-        if (shortened.length > length)
-            shortened = shortened.substring(0,length-1) + '...';
-
-        return shortened;
-    },
-
-    _setEntryLabel: function (menuItem) {
-        let buffer = menuItem.clipContents;
-        menuItem.label.set_text(this._truncate(buffer, MAX_ENTRY_LENGTH));
-    },
-
-    _addEntry: function (buffer, favorite, autoSelect, autoSetClip) {
-        let menuItem = new PopupMenu.PopupMenuItem('');
-
-        menuItem.menu = this.menu;
-        menuItem.clipContents = buffer;
-        menuItem.clipFavorite = favorite;
-        menuItem.radioGroup = this.clipItemsRadioGroup;
-        menuItem.buttonPressId = menuItem.connect('activate',
-            Lang.bind(menuItem, this._onMenuItemSelectedAndMenuClose));
-
-        this._setEntryLabel(menuItem);
-        this.clipItemsRadioGroup.push(menuItem);
-
-	// Favorite button
-        let icon_name = favorite ? 'starred-symbolic' : 'non-starred-symbolic';
-        let iconfav = new St.Icon({
-            icon_name: icon_name,
-            style_class: 'system-status-icon'
-        });
-
-        let icofavBtn = new St.Button({
-            style_class: 'ci-action-btn',
-            can_focus: true,
-            child: iconfav,
-            x_align: Clutter.ActorAlign.END,
-            x_expand: true,
-            y_expand: true
-        });
-
-        menuItem.actor.add_child(icofavBtn);
-        menuItem.icofavBtn = icofavBtn;
-        menuItem.favoritePressId = icofavBtn.connect('button-press-event',
-            Lang.bind(this, function () {
-                this._favoriteToggle(menuItem);
-            })
-        );
-
-	// Delete button
-        let icon = new St.Icon({
-            icon_name: 'edit-delete-symbolic', //'mail-attachment-symbolic',
-            style_class: 'system-status-icon'
-        });
-
-        let icoBtn = new St.Button({
-            style_class: 'ci-action-btn',
-            can_focus: true,
-            child: icon,
-            x_align: Clutter.ActorAlign.END,
-            x_expand: false,
-            y_expand: true
-        });
-
-        menuItem.actor.add_child(icoBtn);
-        menuItem.icoBtn = icoBtn;
-        menuItem.deletePressId = icoBtn.connect('button-press-event',
-            Lang.bind(this, function () {
-                this._removeEntry(menuItem, 'delete');
-            })
-        );
-
-        if (favorite) {
-            this.favoritesSection.addMenuItem(menuItem, 0);
-        } else {
-            this.historySection.addMenuItem(menuItem, 0);
-        }
-
-        if (autoSelect === true)
-            this._selectMenuItem(menuItem, autoSetClip);
-
-        if (TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
-            this._updateButtonText(buffer);
-        }
-
-        this._updateCache();
-    },
-
-    _favoriteToggle: function (menuItem) {
-        menuItem.clipFavorite = menuItem.clipFavorite ? false : true;
-        this._moveItemFirst(menuItem);
-
-        this._updateCache();
-    },
-  
-    _confirmRemoveAll: function () {
-        const title = _("Clear all?");
-        const message = _("Are you sure you want to delete all clipboard items?");
-        const sub_message = _("This operation cannot be undone.");
-
-        ConfirmDialog.openConfirmDialog(title, message, sub_message, _("Clear"), _("Cancel"), () => {
-            let that = this;
-            that._clearHistory();
-        }
-      );
-    },
-
-    _clearHistory: function () {
-        let that = this;
-        // We can't actually remove all items, because the clipboard still
-        // has data that will be re-captured on next refresh, so we remove
-        // all except the currently selected item
-        // Don't remove favorites here
-        that.historySection._getMenuItems().forEach(function (mItem) {
-            if (!mItem.currentlySelected) {
-                let idx = that.clipItemsRadioGroup.indexOf(mItem);
-                mItem.destroy();
-                that.clipItemsRadioGroup.splice(idx, 1);
-            }
-        });
-        that._updateCache();
-        that._showNotification(_("Clipboard history cleared"));    },
-
-    _removeAll: function () {
-        var that = this;
-
-        if (CONFIRM_ON_CLEAR) {
-            that._confirmRemoveAll();
-        } else {
-            that._clearHistory();
-        }
-    },
-
-    _removeEntry: function (menuItem, event) {
-        let itemIdx = this.clipItemsRadioGroup.indexOf(menuItem);
-
-        if(event === 'delete' && menuItem.currentlySelected) {
-            Clipboard.set_text(CLIPBOARD_TYPE, "");
-        }
-
-        menuItem.destroy();
-        this.clipItemsRadioGroup.splice(itemIdx,1);
-
-        this._updateCache();
-    },
-
-    _removeOldestEntries: function () {
-        let that = this;
-
-        let clipItemsRadioGroupNoFavorite = that.clipItemsRadioGroup.filter(
-            item => item.clipFavorite === false);
-
-        while (clipItemsRadioGroupNoFavorite.length > MAX_REGISTRY_LENGTH) {
-            let oldestNoFavorite = clipItemsRadioGroupNoFavorite.shift();
-            that._removeEntry(oldestNoFavorite);
-
-            clipItemsRadioGroupNoFavorite = that.clipItemsRadioGroup.filter(
-                item => item.clipFavorite === false);
-        }
-
-        that._updateCache();
-    },
-
-    _onMenuItemSelected: function (autoSet) {
-        var that = this;
-        that.radioGroup.forEach(function (menuItem) {
-            let clipContents = that.clipContents;
-
-            if (menuItem === that && clipContents) {
-                that.setOrnament(PopupMenu.Ornament.DOT);
-                that.currentlySelected = true;
-                if (autoSet !== false)
-                    Clipboard.set_text(CLIPBOARD_TYPE, clipContents);
-            }
-            else {
-                menuItem.setOrnament(PopupMenu.Ornament.NONE);
-                menuItem.currentlySelected = false;
-            }
-        });
-    },
-
-    _selectMenuItem: function (menuItem, autoSet) {
-        let fn = Lang.bind(menuItem, this._onMenuItemSelected);
-        fn(autoSet);
-        if(TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
-            this._updateButtonText(menuItem.label.text);
-        }
-    },
-
-    _onMenuItemSelectedAndMenuClose: function (autoSet) {
-        var that = this;
-        that.radioGroup.forEach(function (menuItem) {
-            let clipContents = that.clipContents;
-
-            if (menuItem === that && clipContents) {
-                that.setOrnament(PopupMenu.Ornament.DOT);
-                that.currentlySelected = true;
-                if (autoSet !== false)
-                    Clipboard.set_text(CLIPBOARD_TYPE, clipContents);
-            }
-            else {
-                menuItem.setOrnament(PopupMenu.Ornament.NONE);
-                menuItem.currentlySelected = false;
-            }
-        });
-
-        that.menu.close();
-    },
-
-    _getCache: function (cb) {
-        return readRegistry(cb);
-    },
-
-    _updateCache: function () {
-        let registry = this.clipItemsRadioGroup.map(function (menuItem) {
-            return {
-                      "contents" : menuItem.clipContents,
-                      "favorite" : menuItem.clipFavorite
-                   };
-        });
-
-        writeRegistry(registry.filter(function (menuItem) {
-            if (CACHE_ONLY_FAVORITE) {
-                if (menuItem["favorite"]) {
-                    return menuItem;
-                }
-            } else {
-                return menuItem;
-            }
-        }));
-    },
-
-    _onSelectionChange (selection, selectionType, selectionSource) {
-        if (selectionType === Meta.SelectionType.SELECTION_CLIPBOARD) {
-            this._refreshIndicator();
-        }
-    },
-
-    _refreshIndicator: function () {
-        if (PRIVATEMODE) return; // Private mode, do not.
-
-        let that = this;
-
-        Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
-            that._processClipboardContent(text);
-        });
-    },
-
-    _processClipboardContent (text) {
-        const that = this;
-
-        if (STRIP_TEXT) {
-            text = text.trim();
-        }
-
-        if (text !== "" && text) {
-            let registry = that.clipItemsRadioGroup.map(function (menuItem) {
-                return menuItem.clipContents;
-            });
-
-            const itemIndex = registry.indexOf(text);
-
-            if (itemIndex < 0) {
-                that._addEntry(text, false, true, false);
-                that._removeOldestEntries();
-                if (NOTIFY_ON_COPY) {
-                    that._showNotification(_("Copied to clipboard"), notif => {
-                        notif.addAction(_('Cancel'), Lang.bind(that, that._cancelNotification));
-                    });
-                }
-            }
-            else if (itemIndex >= 0 && itemIndex < registry.length - 1) {
-                const item = that._findItem(text);
-                that._selectMenuItem(item, false);
-
-                if (!item.clipFavorite && MOVE_ITEM_FIRST) {
-                    that._moveItemFirst(item);
-                }
-            }
-        }
-    },
-
-    _moveItemFirst: function (item) {
-        this._removeEntry(item);
-        this._addEntry(item.clipContents, item.clipFavorite, item.currentlySelected, false);
-    },
-
-    _findItem: function (text) {
-        return this.clipItemsRadioGroup.filter(
-            item => item.clipContents === text)[0];
-    },
-
-    _getCurrentlySelectedItem () {
-        return this.clipItemsRadioGroup.find(item => item.currentlySelected);
-    },
-
-    _getAllIMenuItems: function (text) {
-        return this.historySection._getMenuItems().concat(this.favoritesSection._getMenuItems());
-    },
-
-    _setupListener () {
-        const metaDisplay = Shell.Global.get().get_display();
-
-        if (typeof metaDisplay.get_selection === 'function') {
-            const selection = metaDisplay.get_selection();
-            this._setupSelectionTracking(selection);
-        }
-        else {
-            this._setupTimeout();
-        }
-    },
-
-    _setupSelectionTracking (selection) {
-        this.selection = selection;
-        this._selectionOwnerChangedId = selection.connect('owner-changed', (selection, selectionType, selectionSource) => {
-            this._onSelectionChange(selection, selectionType, selectionSource);
-        });
-    },
-
-    _setupTimeout: function (reiterate) {
-        let that = this;
-        reiterate = typeof reiterate === 'boolean' ? reiterate : true;
-
-        this._clipboardTimeoutId = Mainloop.timeout_add(TIMEOUT_MS, function () {
-            that._refreshIndicator();
-
-            // If the timeout handler returns `false`, the source is
-            // automatically removed, so we reset the timeout-id so it won't
-            // be removed on `.destroy()`
-            if (reiterate === false)
-                that._clipboardTimeoutId = null;
-
-            // As long as the timeout handler returns `true`, the handler
-            // will be invoked again and again as an interval
-            return reiterate;
-        });
-    },
-
-    _openSettings: function () {
-        if (typeof ExtensionUtils.openPrefs === 'function') {
-            ExtensionUtils.openPrefs();
-        } else {
-            Util.spawn([
-                "gnome-shell-extension-prefs",
-                Me.uuid
-            ]);
-        }
-    },
-
-    _initNotifSource: function () {
-        if (!this._notifSource) {
-            this._notifSource = new MessageTray.Source('ClipboardIndicator',
-                                    INDICATOR_ICON);
-            this._notifSource.connect('destroy', Lang.bind(this, function() {
-                this._notifSource = null;
-            }));
-            Main.messageTray.add(this._notifSource);
-        }
-    },
-
-    _cancelNotification: function() {
-        if (this.clipItemsRadioGroup.length >= 2) {
-            let clipSecond = this.clipItemsRadioGroup.length - 2;
-            let previousClip = this.clipItemsRadioGroup[clipSecond];
-            Clipboard.set_text(CLIPBOARD_TYPE, previousClip.clipContents);
-            previousClip.setOrnament(PopupMenu.Ornament.DOT);
-            previousClip.icoBtn.visible = false;
-            previousClip.currentlySelected = true;
-        } else {
-            Clipboard.set_text(CLIPBOARD_TYPE, "");
-        }
-        let clipFirst = this.clipItemsRadioGroup.length - 1;
-        this._removeEntry(this.clipItemsRadioGroup[clipFirst]);
-    },
-
-    _showNotification: function (message, transformFn) {
-        let notification = null;
-
-        this._initNotifSource();
-
-        if (this._notifSource.count === 0) {
-            notification = new MessageTray.Notification(this._notifSource, message);
-        }
-        else {
-            notification = this._notifSource.notifications[0];
-            notification.update(message, '', { clear: true });
-        }
-
-        if (typeof transformFn === 'function') {
-            transformFn(notification);
-        }
-
-        notification.setTransient(true);
-        if (Config.PACKAGE_VERSION < '3.38')
-            this._notifSource.notify(notification);
-        else
-            this._notifSource.showNotification(notification);
-    },
-
-    _createHistoryLabel: function () {
-        this._historyLabel = new St.Label({
-            style_class: 'ci-notification-label',
-            text: ''
-        });
-
-        global.stage.add_actor(this._historyLabel);
-
-        this._historyLabel.hide();
-    },
-
-    _onPrivateModeSwitch: function() {
-        let that = this;
-        PRIVATEMODE = this.privateModeMenuItem.state;
-        // We hide the history in private ModeTypee because it will be out of sync (selected item will not reflect clipboard)
-        this.scrollViewMenuSection.actor.visible = !PRIVATEMODE;
-        this.scrollViewFavoritesMenuSection.actor.visible = !PRIVATEMODE;
-        // If we get out of private mode then we restore the clipboard to old state
-        if (!PRIVATEMODE) {
-            let selectList = this.clipItemsRadioGroup.filter((item) => !!item.currentlySelected);
-            Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
-                            that._updateButtonText(text);
-                        });
-            if (selectList.length) {
-                this._selectMenuItem(selectList[0]);
-            } else {
-                // Nothing to return to, let's empty it instead
-                Clipboard.set_text(CLIPBOARD_TYPE, "");
-            }
-
-            this.icon.remove_style_class_name('private-mode');
-        } else {
-            this._buttonText.set_text('...');
-            this.icon.add_style_class_name('private-mode');
-        }
-    },
-
-    _loadSettings: function () {
-        this._settings = Prefs.SettingsSchema;
-        this._settingsChangedId = this._settings.connect('changed',
-            Lang.bind(this, this._onSettingsChange));
-
-        this._fetchSettings();
-
-        if (ENABLE_KEYBINDING)
-            this._bindShortcuts();
-    },
-
-    _fetchSettings: function () {
-        TIMEOUT_MS           = this._settings.get_int(Prefs.Fields.INTERVAL);
-        MAX_REGISTRY_LENGTH  = this._settings.get_int(Prefs.Fields.HISTORY_SIZE);
-        MAX_ENTRY_LENGTH     = this._settings.get_int(Prefs.Fields.PREVIEW_SIZE);
-        CACHE_ONLY_FAVORITE  = this._settings.get_boolean(Prefs.Fields.CACHE_ONLY_FAVORITE);
-        DELETE_ENABLED       = this._settings.get_boolean(Prefs.Fields.DELETE);
-        MOVE_ITEM_FIRST      = this._settings.get_boolean(Prefs.Fields.MOVE_ITEM_FIRST);
-        NOTIFY_ON_COPY       = this._settings.get_boolean(Prefs.Fields.NOTIFY_ON_COPY);
-        CONFIRM_ON_CLEAR     = this._settings.get_boolean(Prefs.Fields.CONFIRM_ON_CLEAR);
-        ENABLE_KEYBINDING    = this._settings.get_boolean(Prefs.Fields.ENABLE_KEYBINDING);
-        MAX_TOPBAR_LENGTH    = this._settings.get_int(Prefs.Fields.TOPBAR_PREVIEW_SIZE);
-        TOPBAR_DISPLAY_MODE  = this._settings.get_int(Prefs.Fields.TOPBAR_DISPLAY_MODE_ID);
-        DISABLE_DOWN_ARROW   = this._settings.get_boolean(Prefs.Fields.DISABLE_DOWN_ARROW);
-        STRIP_TEXT           = this._settings.get_boolean(Prefs.Fields.STRIP_TEXT);
-    },
-
-    _onSettingsChange: function () {
-        var that = this;
-
-        // Load the settings into variables
-        that._fetchSettings();
-
-        // Remove old entries in case the registry size changed
-        that._removeOldestEntries();
-
-        // Re-set menu-items lables in case preview size changed
-        this._getAllIMenuItems().forEach(function (mItem) {
-            that._setEntryLabel(mItem);
-        });
-
-        //update topbar
-        this._updateTopbarLayout();
-        if(TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
-            Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
-                that._updateButtonText(text);
-            });
-        }
-
-        // Bind or unbind shortcuts
-        if (ENABLE_KEYBINDING)
-            that._bindShortcuts();
-        else
-            that._unbindShortcuts();
-    },
-
-    _bindShortcuts: function () {
-        this._unbindShortcuts();
-        this._bindShortcut(SETTING_KEY_CLEAR_HISTORY, this._removeAll);
-        this._bindShortcut(SETTING_KEY_PREV_ENTRY, this._previousEntry);
-        this._bindShortcut(SETTING_KEY_NEXT_ENTRY, this._nextEntry);
-        this._bindShortcut(SETTING_KEY_TOGGLE_MENU, this._toggleMenu);
-    },
-
-    _unbindShortcuts: function () {
-        this._shortcutsBindingIds.forEach(
-            (id) => Main.wm.removeKeybinding(id)
-        );
-
-        this._shortcutsBindingIds = [];
-    },
-
-    _bindShortcut: function(name, cb) {
-        var ModeType = Shell.hasOwnProperty('ActionMode') ?
-            Shell.ActionMode : Shell.KeyBindingMode;
-
-        Main.wm.addKeybinding(
-            name,
-            this._settings,
-            Meta.KeyBindingFlags.NONE,
-            ModeType.ALL,
-            Lang.bind(this, cb)
-        );
-
-        this._shortcutsBindingIds.push(name);
-    },
-
-    _updateTopbarLayout: function(){
-        if(TOPBAR_DISPLAY_MODE === 0){
-            this.icon.visible = true;
-            this._buttonText.visible = false;
-        }
-        if(TOPBAR_DISPLAY_MODE === 1){
-            this.icon.visible = false;
-            this._buttonText.visible = true;
-        }
-        if(TOPBAR_DISPLAY_MODE === 2){
-            this.icon.visible = true;
-            this._buttonText.visible = true;
-        }
-        if(!DISABLE_DOWN_ARROW) {
-            this._downArrow.visible = true;
-        } else {
-            this._downArrow.visible = false;
-        }
-    },
-
-    _disconnectSettings: function () {
-        if (!this._settingsChangedId)
-            return;
-
-        this._settings.disconnect(this._settingsChangedId);
-        this._settingsChangedId = null;
-    },
-
-    _clearClipboardTimeout: function () {
-        if (!this._clipboardTimeoutId)
-            return;
-
-        Mainloop.source_remove(this._clipboardTimeoutId);
-        this._clipboardTimeoutId = null;
-    },
-
-    _disconnectSelectionListener () {
-        if (!this._selectionOwnerChangedId)
-            return;
-
-        this.selection.disconnect(this._selectionOwnerChangedId);
-    },
-
-    _clearLabelTimeout: function () {
-        if (!this._historyLabelTimeoutId)
-            return;
-
-        Mainloop.source_remove(this._historyLabelTimeoutId);
-        this._historyLabelTimeoutId = null;
-    },
-
-    _clearDelayedSelectionTimeout: function () {
-        if (this._delayedSelectionTimeoutId) {
-            Mainloop.source_remove(this._delayedSelectionTimeoutId);
-        }
-    },
-
-    _selectEntryWithDelay: function (entry) {
-        let that = this;
-
-        that._selectMenuItem(entry, false);
-        that._delayedSelectionTimeoutId = Mainloop.timeout_add(
-                TIMEOUT_MS * 0.75, function () {
-
-            that._selectMenuItem(entry);  //select the item
-
-            that._delayedSelectionTimeoutId = null;
-            return false;
-        });
-    },
-
-    _previousEntry: function() {
-        let that = this;
-
-        that._clearDelayedSelectionTimeout();
-
-        this._getAllIMenuItems().some(function (mItem, i, menuItems){
-            if (mItem.currentlySelected) {
-                i--;                                 //get the previous index
-                if (i < 0) i = menuItems.length - 1; //cycle if out of bound
-                let index = i + 1;                   //index to be displayed
-                that._showNotification(index + ' / ' + menuItems.length + ': ' + menuItems[i].label.text);
-                if (MOVE_ITEM_FIRST) {
-                    that._selectEntryWithDelay(menuItems[i]);
-                }
-                else {
-                    that._selectMenuItem(menuItems[i]);
-                }
-                return true;
-            }
-            return false;
-        });
-    },
-
-    _nextEntry: function() {
-        let that = this;
-
-        that._clearDelayedSelectionTimeout();
-
-        this._getAllIMenuItems().some(function (mItem, i, menuItems){
-            if (mItem.currentlySelected) {
-                i++;                                 //get the next index
-                if (i === menuItems.length) i = 0;   //cycle if out of bound
-                let index = i + 1;                     //index to be displayed
-                that._showNotification(index + ' / ' + menuItems.length + ': ' + menuItems[i].label.text);
-                if (MOVE_ITEM_FIRST) {
-                    that._selectEntryWithDelay(menuItems[i]);
-                }
-                else {
-                    that._selectMenuItem(menuItems[i]);
-                }
-                return true;
-            }
-            return false;
-        });
-    },
-
-    _toggleMenu: function(){
-        this.menu.toggle();
+  _onSearchTextChanged: function () {
+    let searchedText = this.searchEntry.get_text().toLowerCase();
+
+    if (searchedText === '') {
+      this._getAllIMenuItems().forEach(function (mItem) {
+        mItem.actor.visible = true;
+      });
+    } else {
+      this._getAllIMenuItems().forEach(function (mItem) {
+        let text = mItem.clipContents.toLowerCase();
+        let isMatching = text.indexOf(searchedText) >= 0;
+        mItem.actor.visible = isMatching;
+      });
     }
+  },
+
+  _truncate: function (string, length) {
+    let shortened = string.replace(/\s+/g, ' ');
+
+    if (shortened.length > length) {
+      shortened = shortened.substring(0, length - 1) + '...';
+    }
+
+    return shortened;
+  },
+
+  _setEntryLabel: function (menuItem) {
+    let buffer = menuItem.clipContents;
+    menuItem.label.set_text(this._truncate(buffer, MAX_ENTRY_LENGTH));
+  },
+
+  _addEntry: function (buffer, favorite, autoSelect, autoSetClip) {
+    let menuItem = new PopupMenu.PopupMenuItem('');
+
+    menuItem.menu = this.menu;
+    menuItem.clipContents = buffer;
+    menuItem.clipFavorite = favorite;
+    menuItem.radioGroup = this.clipItemsRadioGroup;
+    menuItem.buttonPressId = menuItem.connect(
+      'activate',
+      Lang.bind(menuItem, this._onMenuItemSelectedAndMenuClose),
+    );
+
+    this._setEntryLabel(menuItem);
+    this.clipItemsRadioGroup.push(menuItem);
+
+    // Favorite button
+    let icon_name = favorite ? 'starred-symbolic' : 'non-starred-symbolic';
+    let iconfav = new St.Icon({
+      icon_name: icon_name,
+      style_class: 'system-status-icon',
+    });
+
+    let icofavBtn = new St.Button({
+      style_class: 'ci-action-btn',
+      can_focus: true,
+      child: iconfav,
+      x_align: Clutter.ActorAlign.END,
+      x_expand: true,
+      y_expand: true,
+    });
+
+    menuItem.actor.add_child(icofavBtn);
+    menuItem.icofavBtn = icofavBtn;
+    menuItem.favoritePressId = icofavBtn.connect(
+      'button-press-event',
+      Lang.bind(this, function () {
+        this._favoriteToggle(menuItem);
+      }),
+    );
+
+    // Delete button
+    let icon = new St.Icon({
+      icon_name: 'edit-delete-symbolic', //'mail-attachment-symbolic',
+      style_class: 'system-status-icon',
+    });
+
+    let icoBtn = new St.Button({
+      style_class: 'ci-action-btn',
+      can_focus: true,
+      child: icon,
+      x_align: Clutter.ActorAlign.END,
+      x_expand: false,
+      y_expand: true,
+    });
+
+    menuItem.actor.add_child(icoBtn);
+    menuItem.icoBtn = icoBtn;
+    menuItem.deletePressId = icoBtn.connect(
+      'button-press-event',
+      Lang.bind(this, function () {
+        this._removeEntry(menuItem, 'delete');
+      }),
+    );
+
+    if (favorite) {
+      this.favoritesSection.addMenuItem(menuItem, 0);
+    } else {
+      this.historySection.addMenuItem(menuItem, 0);
+    }
+
+    if (autoSelect === true) {
+      this._selectMenuItem(menuItem, autoSetClip);
+    }
+
+    if (TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
+      this._updateButtonText(buffer);
+    }
+
+    this._updateCache();
+  },
+
+  _favoriteToggle: function (menuItem) {
+    menuItem.clipFavorite = menuItem.clipFavorite ? false : true;
+    this._moveItemFirst(menuItem);
+
+    this._updateCache();
+  },
+
+  _confirmRemoveAll: function () {
+    const title = _('Clear all?');
+    const message = _('Are you sure you want to delete all clipboard items?');
+    const sub_message = _('This operation cannot be undone.');
+
+    ConfirmDialog.openConfirmDialog(
+      title,
+      message,
+      sub_message,
+      _('Clear'),
+      _('Cancel'),
+      () => {
+        let that = this;
+        that._clearHistory();
+      },
+    );
+  },
+
+  _clearHistory: function () {
+    let that = this;
+    // We can't actually remove all items, because the clipboard still
+    // has data that will be re-captured on next refresh, so we remove
+    // all except the currently selected item
+    // Don't remove favorites here
+    that.historySection._getMenuItems().forEach(function (mItem) {
+      if (!mItem.currentlySelected) {
+        let idx = that.clipItemsRadioGroup.indexOf(mItem);
+        mItem.destroy();
+        that.clipItemsRadioGroup.splice(idx, 1);
+      }
+    });
+    that._updateCache();
+    that._showNotification(_('Clipboard history cleared'));
+  },
+
+  _removeAll: function () {
+    var that = this;
+
+    if (CONFIRM_ON_CLEAR) {
+      that._confirmRemoveAll();
+    } else {
+      that._clearHistory();
+    }
+  },
+
+  _removeEntry: function (menuItem, event) {
+    let itemIdx = this.clipItemsRadioGroup.indexOf(menuItem);
+
+    if (event === 'delete' && menuItem.currentlySelected) {
+      Clipboard.set_text(CLIPBOARD_TYPE, '');
+    }
+
+    menuItem.destroy();
+    this.clipItemsRadioGroup.splice(itemIdx, 1);
+
+    this._updateCache();
+  },
+
+  _removeOldestEntries: function () {
+    let that = this;
+
+    let clipItemsRadioGroupNoFavorite = that.clipItemsRadioGroup.filter(
+      (item) => item.clipFavorite === false,
+    );
+
+    while (clipItemsRadioGroupNoFavorite.length > MAX_REGISTRY_LENGTH) {
+      let oldestNoFavorite = clipItemsRadioGroupNoFavorite.shift();
+      that._removeEntry(oldestNoFavorite);
+
+      clipItemsRadioGroupNoFavorite = that.clipItemsRadioGroup.filter(
+        (item) => item.clipFavorite === false,
+      );
+    }
+
+    that._updateCache();
+  },
+
+  _onMenuItemSelected: function (autoSet) {
+    var that = this;
+    that.radioGroup.forEach(function (menuItem) {
+      let clipContents = that.clipContents;
+
+      if (menuItem === that && clipContents) {
+        that.setOrnament(PopupMenu.Ornament.DOT);
+        that.currentlySelected = true;
+        if (autoSet !== false) {
+          Clipboard.set_text(CLIPBOARD_TYPE, clipContents);
+        }
+      } else {
+        menuItem.setOrnament(PopupMenu.Ornament.NONE);
+        menuItem.currentlySelected = false;
+      }
+    });
+  },
+
+  _selectMenuItem: function (menuItem, autoSet) {
+    let fn = Lang.bind(menuItem, this._onMenuItemSelected);
+    fn(autoSet);
+    if (TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
+      this._updateButtonText(menuItem.label.text);
+    }
+  },
+
+  _onMenuItemSelectedAndMenuClose: function (autoSet) {
+    var that = this;
+    that.radioGroup.forEach(function (menuItem) {
+      let clipContents = that.clipContents;
+
+      if (menuItem === that && clipContents) {
+        that.setOrnament(PopupMenu.Ornament.DOT);
+        that.currentlySelected = true;
+        if (autoSet !== false) {
+          Clipboard.set_text(CLIPBOARD_TYPE, clipContents);
+        }
+      } else {
+        menuItem.setOrnament(PopupMenu.Ornament.NONE);
+        menuItem.currentlySelected = false;
+      }
+    });
+
+    that.menu.close();
+  },
+
+  _getCache: function (cb) {
+    return readRegistry(cb);
+  },
+
+  _updateCache: function () {
+    let registry = this.clipItemsRadioGroup.map(function (menuItem) {
+      return {
+        contents: menuItem.clipContents,
+        favorite: menuItem.clipFavorite,
+      };
+    });
+
+    writeRegistry(
+      registry.filter(function (menuItem) {
+        if (CACHE_ONLY_FAVORITE) {
+          if (menuItem['favorite']) {
+            return menuItem;
+          }
+        } else {
+          return menuItem;
+        }
+      }),
+    );
+  },
+
+  _onSelectionChange(selection, selectionType, selectionSource) {
+    if (selectionType === Meta.SelectionType.SELECTION_CLIPBOARD) {
+      this._refreshIndicator();
+    }
+  },
+
+  _refreshIndicator: function () {
+    if (PRIVATEMODE) return; // Private mode, do not.
+
+    let that = this;
+
+    Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
+      that._processClipboardContent(text);
+    });
+  },
+
+  _processClipboardContent(text) {
+    const that = this;
+
+    if (STRIP_TEXT) {
+      text = text.trim();
+    }
+
+    if (text !== '' && text) {
+      let registry = that.clipItemsRadioGroup.map(function (menuItem) {
+        return menuItem.clipContents;
+      });
+
+      const itemIndex = registry.indexOf(text);
+
+      if (itemIndex < 0) {
+        that._addEntry(text, false, true, false);
+        that._removeOldestEntries();
+        if (NOTIFY_ON_COPY) {
+          that._showNotification(_('Copied to clipboard'), (notif) => {
+            notif.addAction(
+              _('Cancel'),
+              Lang.bind(that, that._cancelNotification),
+            );
+          });
+        }
+      } else if (itemIndex >= 0 && itemIndex < registry.length - 1) {
+        const item = that._findItem(text);
+        that._selectMenuItem(item, false);
+
+        if (!item.clipFavorite && MOVE_ITEM_FIRST) {
+          that._moveItemFirst(item);
+        }
+      }
+    }
+  },
+
+  _moveItemFirst: function (item) {
+    this._removeEntry(item);
+    this._addEntry(
+      item.clipContents,
+      item.clipFavorite,
+      item.currentlySelected,
+      false,
+    );
+  },
+
+  _findItem: function (text) {
+    return this.clipItemsRadioGroup.filter(
+      (item) => item.clipContents === text,
+    )[0];
+  },
+
+  _getCurrentlySelectedItem() {
+    return this.clipItemsRadioGroup.find((item) => item.currentlySelected);
+  },
+
+  _getAllIMenuItems: function (text) {
+    return this.historySection
+      ._getMenuItems()
+      .concat(this.favoritesSection._getMenuItems());
+  },
+
+  _setupListener() {
+    const metaDisplay = Shell.Global.get().get_display();
+
+    if (typeof metaDisplay.get_selection === 'function') {
+      const selection = metaDisplay.get_selection();
+      this._setupSelectionTracking(selection);
+    } else {
+      this._setupTimeout();
+    }
+  },
+
+  _setupSelectionTracking(selection) {
+    this.selection = selection;
+    this._selectionOwnerChangedId = selection.connect(
+      'owner-changed',
+      (selection, selectionType, selectionSource) => {
+        this._onSelectionChange(selection, selectionType, selectionSource);
+      },
+    );
+  },
+
+  _setupTimeout: function (reiterate) {
+    let that = this;
+    reiterate = typeof reiterate === 'boolean' ? reiterate : true;
+
+    this._clipboardTimeoutId = Mainloop.timeout_add(TIMEOUT_MS, function () {
+      that._refreshIndicator();
+
+      // If the timeout handler returns `false`, the source is
+      // automatically removed, so we reset the timeout-id so it won't
+      // be removed on `.destroy()`
+      if (reiterate === false) {
+        that._clipboardTimeoutId = null;
+      }
+
+      // As long as the timeout handler returns `true`, the handler
+      // will be invoked again and again as an interval
+      return reiterate;
+    });
+  },
+
+  _openSettings: function () {
+    if (typeof ExtensionUtils.openPrefs === 'function') {
+      ExtensionUtils.openPrefs();
+    } else {
+      Util.spawn(['gnome-shell-extension-prefs', Me.uuid]);
+    }
+  },
+
+  _initNotifSource: function () {
+    if (!this._notifSource) {
+      this._notifSource = new MessageTray.Source(
+        'ClipboardIndicator',
+        INDICATOR_ICON,
+      );
+      this._notifSource.connect(
+        'destroy',
+        Lang.bind(this, function () {
+          this._notifSource = null;
+        }),
+      );
+      Main.messageTray.add(this._notifSource);
+    }
+  },
+
+  _cancelNotification: function () {
+    if (this.clipItemsRadioGroup.length >= 2) {
+      let clipSecond = this.clipItemsRadioGroup.length - 2;
+      let previousClip = this.clipItemsRadioGroup[clipSecond];
+      Clipboard.set_text(CLIPBOARD_TYPE, previousClip.clipContents);
+      previousClip.setOrnament(PopupMenu.Ornament.DOT);
+      previousClip.icoBtn.visible = false;
+      previousClip.currentlySelected = true;
+    } else {
+      Clipboard.set_text(CLIPBOARD_TYPE, '');
+    }
+    let clipFirst = this.clipItemsRadioGroup.length - 1;
+    this._removeEntry(this.clipItemsRadioGroup[clipFirst]);
+  },
+
+  _showNotification: function (message, transformFn) {
+    let notification = null;
+
+    this._initNotifSource();
+
+    if (this._notifSource.count === 0) {
+      notification = new MessageTray.Notification(this._notifSource, message);
+    } else {
+      notification = this._notifSource.notifications[0];
+      notification.update(message, '', { clear: true });
+    }
+
+    if (typeof transformFn === 'function') {
+      transformFn(notification);
+    }
+
+    notification.setTransient(true);
+    if (Config.PACKAGE_VERSION < '3.38') {
+      this._notifSource.notify(notification);
+    } else {
+      this._notifSource.showNotification(notification);
+    }
+  },
+
+  _createHistoryLabel: function () {
+    this._historyLabel = new St.Label({
+      style_class: 'ci-notification-label',
+      text: '',
+    });
+
+    global.stage.add_actor(this._historyLabel);
+
+    this._historyLabel.hide();
+  },
+
+  _onPrivateModeSwitch: function () {
+    let that = this;
+    PRIVATEMODE = this.privateModeMenuItem.state;
+    // We hide the history in private ModeTypee because it will be out of sync (selected item will not reflect clipboard)
+    this.scrollViewMenuSection.actor.visible = !PRIVATEMODE;
+    this.scrollViewFavoritesMenuSection.actor.visible = !PRIVATEMODE;
+    // If we get out of private mode then we restore the clipboard to old state
+    if (!PRIVATEMODE) {
+      let selectList = this.clipItemsRadioGroup.filter(
+        (item) => !!item.currentlySelected,
+      );
+      Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
+        that._updateButtonText(text);
+      });
+      if (selectList.length) {
+        this._selectMenuItem(selectList[0]);
+      } else {
+        // Nothing to return to, let's empty it instead
+        Clipboard.set_text(CLIPBOARD_TYPE, '');
+      }
+
+      this.icon.remove_style_class_name('private-mode');
+    } else {
+      this._buttonText.set_text('...');
+      this.icon.add_style_class_name('private-mode');
+    }
+  },
+
+  _loadSettings: function () {
+    this._settings = Prefs.SettingsSchema;
+    this._settingsChangedId = this._settings.connect(
+      'changed',
+      Lang.bind(this, this._onSettingsChange),
+    );
+
+    this._fetchSettings();
+
+    if (ENABLE_KEYBINDING) {
+      this._bindShortcuts();
+    }
+  },
+
+  _fetchSettings: function () {
+    TIMEOUT_MS = this._settings.get_int(Prefs.Fields.INTERVAL);
+    MAX_REGISTRY_LENGTH = this._settings.get_int(Prefs.Fields.HISTORY_SIZE);
+    MAX_ENTRY_LENGTH = this._settings.get_int(Prefs.Fields.PREVIEW_SIZE);
+    CACHE_ONLY_FAVORITE = this._settings.get_boolean(
+      Prefs.Fields.CACHE_ONLY_FAVORITE,
+    );
+    DELETE_ENABLED = this._settings.get_boolean(Prefs.Fields.DELETE);
+    MOVE_ITEM_FIRST = this._settings.get_boolean(Prefs.Fields.MOVE_ITEM_FIRST);
+    NOTIFY_ON_COPY = this._settings.get_boolean(Prefs.Fields.NOTIFY_ON_COPY);
+    CONFIRM_ON_CLEAR = this._settings.get_boolean(
+      Prefs.Fields.CONFIRM_ON_CLEAR,
+    );
+    ENABLE_KEYBINDING = this._settings.get_boolean(
+      Prefs.Fields.ENABLE_KEYBINDING,
+    );
+    MAX_TOPBAR_LENGTH = this._settings.get_int(
+      Prefs.Fields.TOPBAR_PREVIEW_SIZE,
+    );
+    TOPBAR_DISPLAY_MODE = this._settings.get_int(
+      Prefs.Fields.TOPBAR_DISPLAY_MODE_ID,
+    );
+    DISABLE_DOWN_ARROW = this._settings.get_boolean(
+      Prefs.Fields.DISABLE_DOWN_ARROW,
+    );
+    STRIP_TEXT = this._settings.get_boolean(Prefs.Fields.STRIP_TEXT);
+  },
+
+  _onSettingsChange: function () {
+    var that = this;
+
+    // Load the settings into variables
+    that._fetchSettings();
+
+    // Remove old entries in case the registry size changed
+    that._removeOldestEntries();
+
+    // Re-set menu-items lables in case preview size changed
+    this._getAllIMenuItems().forEach(function (mItem) {
+      that._setEntryLabel(mItem);
+    });
+
+    //update topbar
+    this._updateTopbarLayout();
+    if (TOPBAR_DISPLAY_MODE === 1 || TOPBAR_DISPLAY_MODE === 2) {
+      Clipboard.get_text(CLIPBOARD_TYPE, function (clipBoard, text) {
+        that._updateButtonText(text);
+      });
+    }
+
+    // Bind or unbind shortcuts
+    if (ENABLE_KEYBINDING) {
+      that._bindShortcuts();
+    } else {
+      that._unbindShortcuts();
+    }
+  },
+
+  _bindShortcuts: function () {
+    this._unbindShortcuts();
+    this._bindShortcut(SETTING_KEY_CLEAR_HISTORY, this._removeAll);
+    this._bindShortcut(SETTING_KEY_PREV_ENTRY, this._previousEntry);
+    this._bindShortcut(SETTING_KEY_NEXT_ENTRY, this._nextEntry);
+    this._bindShortcut(SETTING_KEY_TOGGLE_MENU, this._toggleMenu);
+  },
+
+  _unbindShortcuts: function () {
+    this._shortcutsBindingIds.forEach((id) => Main.wm.removeKeybinding(id));
+
+    this._shortcutsBindingIds = [];
+  },
+
+  _bindShortcut: function (name, cb) {
+    var ModeType = Shell.hasOwnProperty('ActionMode')
+      ? Shell.ActionMode
+      : Shell.KeyBindingMode;
+
+    Main.wm.addKeybinding(
+      name,
+      this._settings,
+      Meta.KeyBindingFlags.NONE,
+      ModeType.ALL,
+      Lang.bind(this, cb),
+    );
+
+    this._shortcutsBindingIds.push(name);
+  },
+
+  _updateTopbarLayout: function () {
+    if (TOPBAR_DISPLAY_MODE === 0) {
+      this.icon.visible = true;
+      this._buttonText.visible = false;
+    }
+    if (TOPBAR_DISPLAY_MODE === 1) {
+      this.icon.visible = false;
+      this._buttonText.visible = true;
+    }
+    if (TOPBAR_DISPLAY_MODE === 2) {
+      this.icon.visible = true;
+      this._buttonText.visible = true;
+    }
+    if (!DISABLE_DOWN_ARROW) {
+      this._downArrow.visible = true;
+    } else {
+      this._downArrow.visible = false;
+    }
+  },
+
+  _disconnectSettings: function () {
+    if (!this._settingsChangedId) {
+      return;
+    }
+
+    this._settings.disconnect(this._settingsChangedId);
+    this._settingsChangedId = null;
+  },
+
+  _clearClipboardTimeout: function () {
+    if (!this._clipboardTimeoutId) {
+      return;
+    }
+
+    Mainloop.source_remove(this._clipboardTimeoutId);
+    this._clipboardTimeoutId = null;
+  },
+
+  _disconnectSelectionListener() {
+    if (!this._selectionOwnerChangedId) {
+      return;
+    }
+
+    this.selection.disconnect(this._selectionOwnerChangedId);
+  },
+
+  _clearLabelTimeout: function () {
+    if (!this._historyLabelTimeoutId) {
+      return;
+    }
+
+    Mainloop.source_remove(this._historyLabelTimeoutId);
+    this._historyLabelTimeoutId = null;
+  },
+
+  _clearDelayedSelectionTimeout: function () {
+    if (this._delayedSelectionTimeoutId) {
+      Mainloop.source_remove(this._delayedSelectionTimeoutId);
+    }
+  },
+
+  _selectEntryWithDelay: function (entry) {
+    let that = this;
+
+    that._selectMenuItem(entry, false);
+    that._delayedSelectionTimeoutId = Mainloop.timeout_add(
+      TIMEOUT_MS * 0.75,
+      function () {
+        that._selectMenuItem(entry); //select the item
+
+        that._delayedSelectionTimeoutId = null;
+        return false;
+      },
+    );
+  },
+
+  _previousEntry: function () {
+    let that = this;
+
+    that._clearDelayedSelectionTimeout();
+
+    this._getAllIMenuItems().some(function (mItem, i, menuItems) {
+      if (mItem.currentlySelected) {
+        i--; //get the previous index
+        if (i < 0) {
+          i = menuItems.length - 1;
+        } //cycle if out of bound
+        let index = i + 1; //index to be displayed
+        that._showNotification(
+          index + ' / ' + menuItems.length + ': ' + menuItems[i].label.text,
+        );
+        if (MOVE_ITEM_FIRST) {
+          that._selectEntryWithDelay(menuItems[i]);
+        } else {
+          that._selectMenuItem(menuItems[i]);
+        }
+        return true;
+      }
+      return false;
+    });
+  },
+
+  _nextEntry: function () {
+    let that = this;
+
+    that._clearDelayedSelectionTimeout();
+
+    this._getAllIMenuItems().some(function (mItem, i, menuItems) {
+      if (mItem.currentlySelected) {
+        i++; //get the next index
+        if (i === menuItems.length) {
+          i = 0;
+        } //cycle if out of bound
+        let index = i + 1; //index to be displayed
+        that._showNotification(
+          index + ' / ' + menuItems.length + ': ' + menuItems[i].label.text,
+        );
+        if (MOVE_ITEM_FIRST) {
+          that._selectEntryWithDelay(menuItems[i]);
+        } else {
+          that._selectMenuItem(menuItems[i]);
+        }
+        return true;
+      }
+      return false;
+    });
+  },
+
+  _toggleMenu: function () {
+    this.menu.toggle();
+  },
 });
 
-
-function init () {
-    let localeDir = Me.dir.get_child('locale');
-    Gettext.bindtextdomain('clipboard-indicator', localeDir.get_path());
+function init() {
+  let localeDir = Me.dir.get_child('locale');
+  Gettext.bindtextdomain('clipboard-indicator', localeDir.get_path());
 }
 
 let clipboardIndicator;
-function enable () {
-    clipboardIndicator = new ClipboardIndicator();
-    Main.panel.addToStatusArea('clipboardIndicator', clipboardIndicator, 1);
+
+function enable() {
+  clipboardIndicator = new ClipboardIndicator();
+  Main.panel.addToStatusArea('clipboardIndicator', clipboardIndicator, 1);
 }
 
-function disable () {
-    clipboardIndicator.destroy();
+function disable() {
+  clipboardIndicator.destroy();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,7 @@
 {
-    "shell-version": [
-        "40",
-        "41"
-    ],
-    "uuid": "clipboard-indicator@tudmotu.com",
-    "name": "Clipboard Indicator",
-    "description": "Clipboard Manager extension for Gnome-Shell - Adds a clipboard indicator to the top panel, and caches clipboard history.",
-    "url": "https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator"
+  "shell-version": ["40", "41"],
+  "uuid": "clipboard-indicator@tudmotu.com",
+  "name": "Clipboard Indicator",
+  "description": "Clipboard Manager extension for Gnome-Shell - Adds a clipboard indicator to the top panel, and caches clipboard history.",
+  "url": "https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "gnome-shell-extension-clipboard-indicator",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "2.5.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "prettier": "2.5.1"
+  }
+}

--- a/prefs.js
+++ b/prefs.js
@@ -10,344 +10,440 @@ const Gettext = imports.gettext;
 const _ = Gettext.domain('clipboard-indicator').gettext;
 
 var Fields = {
-    INTERVAL               : 'refresh-interval',
-    HISTORY_SIZE           : 'history-size',
-    PREVIEW_SIZE           : 'preview-size',
-    CACHE_FILE_SIZE        : 'cache-size',
-    CACHE_ONLY_FAVORITE    : 'cache-only-favorites',
-    DELETE                 : 'enable-deletion',
-    NOTIFY_ON_COPY         : 'notify-on-copy',
-    CONFIRM_ON_CLEAR       : 'confirm-clear',
-    MOVE_ITEM_FIRST        : 'move-item-first',
-    ENABLE_KEYBINDING      : 'enable-keybindings',
-    TOPBAR_PREVIEW_SIZE    : 'topbar-preview-size',
-    TOPBAR_DISPLAY_MODE_ID : 'display-mode',
-    DISABLE_DOWN_ARROW     : 'disable-down-arrow',
-    STRIP_TEXT             : 'strip-text'
+  INTERVAL: 'refresh-interval',
+  HISTORY_SIZE: 'history-size',
+  PREVIEW_SIZE: 'preview-size',
+  CACHE_FILE_SIZE: 'cache-size',
+  CACHE_ONLY_FAVORITE: 'cache-only-favorites',
+  DELETE: 'enable-deletion',
+  NOTIFY_ON_COPY: 'notify-on-copy',
+  CONFIRM_ON_CLEAR: 'confirm-clear',
+  MOVE_ITEM_FIRST: 'move-item-first',
+  ENABLE_KEYBINDING: 'enable-keybindings',
+  TOPBAR_PREVIEW_SIZE: 'topbar-preview-size',
+  TOPBAR_DISPLAY_MODE_ID: 'display-mode',
+  DISABLE_DOWN_ARROW: 'disable-down-arrow',
+  STRIP_TEXT: 'strip-text',
 };
 
 const SCHEMA_NAME = 'org.gnome.shell.extensions.clipboard-indicator';
 
 const getSchema = function () {
-    let schemaDir = Extension.dir.get_child('schemas').get_path();
-    let schemaSource = Gio.SettingsSchemaSource.new_from_directory(schemaDir, Gio.SettingsSchemaSource.get_default(), false);
-    let schema = schemaSource.lookup(SCHEMA_NAME, false);
+  let schemaDir = Extension.dir.get_child('schemas').get_path();
+  let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
+    schemaDir,
+    Gio.SettingsSchemaSource.get_default(),
+    false,
+  );
+  let schema = schemaSource.lookup(SCHEMA_NAME, false);
 
-    return new Gio.Settings({ settings_schema: schema });
+  return new Gio.Settings({ settings_schema: schema });
 };
 
 var SettingsSchema = getSchema();
 
-
 function init() {
-    let localeDir = Extension.dir.get_child('locale');
-    if (localeDir.query_exists(null))
-        Gettext.bindtextdomain('clipboard-indicator', localeDir.get_path());
+  let localeDir = Extension.dir.get_child('locale');
+  if (localeDir.query_exists(null))
+    Gettext.bindtextdomain('clipboard-indicator', localeDir.get_path());
 }
 
 const App = new Lang.Class({
-    Name: 'ClipboardIndicator.App',
-    _init: function() {
-        this.main = new Gtk.Grid({
-            margin_top: 10,
-            margin_bottom: 10,
-            margin_start: 10,
-            margin_end: 10,
-            row_spacing: 12,
-            column_spacing: 18,
-            column_homogeneous: false,
-            row_homogeneous: false
-        });
-        this.field_interval = new Gtk.SpinButton({
-            adjustment: new Gtk.Adjustment({
-                lower: 500,
-                upper: 5000,
-                step_increment: 100
-            })
-        });
-        this.field_size = new Gtk.SpinButton({
-            adjustment: new Gtk.Adjustment({
-                lower: 1,
-                upper: 200,
-                step_increment: 1
-            })
-        });
-        this.field_preview_size = new Gtk.SpinButton({
-            adjustment: new Gtk.Adjustment({
-                lower: 10,
-                upper: 100,
-                step_increment: 1
-            })
-        });
-        this.field_cache_size = new Gtk.SpinButton({
-            adjustment: new Gtk.Adjustment({
-                lower: 512,
-                upper: Math.pow(2, 14),
-                step_increment: 1
-            })
-        });
-        this.field_topbar_preview_size = new Gtk.SpinButton({
-            adjustment: new Gtk.Adjustment({
-                lower: 1,
-                upper: 100,
-                step_increment: 1
-            })
-        });
-        this.field_display_mode = new Gtk.ComboBox({
-            model: this._create_display_mode_options()});
+  Name: 'ClipboardIndicator.App',
+  _init: function () {
+    this.main = new Gtk.Grid({
+      margin_top: 10,
+      margin_bottom: 10,
+      margin_start: 10,
+      margin_end: 10,
+      row_spacing: 12,
+      column_spacing: 18,
+      column_homogeneous: false,
+      row_homogeneous: false,
+    });
+    this.field_interval = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        lower: 500,
+        upper: 5000,
+        step_increment: 100,
+      }),
+    });
+    this.field_size = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        lower: 1,
+        upper: 200,
+        step_increment: 1,
+      }),
+    });
+    this.field_preview_size = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        lower: 10,
+        upper: 100,
+        step_increment: 1,
+      }),
+    });
+    this.field_cache_size = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        lower: 512,
+        upper: Math.pow(2, 14),
+        step_increment: 1,
+      }),
+    });
+    this.field_topbar_preview_size = new Gtk.SpinButton({
+      adjustment: new Gtk.Adjustment({
+        lower: 1,
+        upper: 100,
+        step_increment: 1,
+      }),
+    });
+    this.field_display_mode = new Gtk.ComboBox({
+      model: this._create_display_mode_options(),
+    });
 
-        let rendererText = new Gtk.CellRendererText();
-        this.field_display_mode.pack_start (rendererText, false);
-        this.field_display_mode.add_attribute (rendererText, "text", 0);
-        this.field_disable_down_arrow = new Gtk.Switch();
-        this.field_cache_disable = new Gtk.Switch();
-        this.field_notification_toggle = new Gtk.Switch();
-        this.field_confirm_clear_toggle = new Gtk.Switch();
-        this.field_strip_text = new Gtk.Switch();
-        this.field_move_item_first = new Gtk.Switch();
-        this.field_keybinding = createKeybindingWidget(SettingsSchema);
-        addKeybinding(this.field_keybinding.model, SettingsSchema, "toggle-menu",
-                      _("Toggle the menu"));
-        addKeybinding(this.field_keybinding.model, SettingsSchema, "clear-history",
-                      _("Clear history"));
-        addKeybinding(this.field_keybinding.model, SettingsSchema, "prev-entry",
-                      _("Previous entry"));
-        addKeybinding(this.field_keybinding.model, SettingsSchema, "next-entry",
-                      _("Next entry"));
+    let rendererText = new Gtk.CellRendererText();
+    this.field_display_mode.pack_start(rendererText, false);
+    this.field_display_mode.add_attribute(rendererText, 'text', 0);
+    this.field_disable_down_arrow = new Gtk.Switch();
+    this.field_cache_disable = new Gtk.Switch();
+    this.field_notification_toggle = new Gtk.Switch();
+    this.field_confirm_clear_toggle = new Gtk.Switch();
+    this.field_strip_text = new Gtk.Switch();
+    this.field_move_item_first = new Gtk.Switch();
+    this.field_keybinding = createKeybindingWidget(SettingsSchema);
+    addKeybinding(
+      this.field_keybinding.model,
+      SettingsSchema,
+      'toggle-menu',
+      _('Toggle the menu'),
+    );
+    addKeybinding(
+      this.field_keybinding.model,
+      SettingsSchema,
+      'clear-history',
+      _('Clear history'),
+    );
+    addKeybinding(
+      this.field_keybinding.model,
+      SettingsSchema,
+      'prev-entry',
+      _('Previous entry'),
+    );
+    addKeybinding(
+      this.field_keybinding.model,
+      SettingsSchema,
+      'next-entry',
+      _('Next entry'),
+    );
 
-        var that = this;
-        this.field_keybinding_activation = new Gtk.Switch();
-        this.field_keybinding_activation.connect("notify::active", function(widget){
-            that.field_keybinding.set_sensitive(widget.active);
-        });
+    var that = this;
+    this.field_keybinding_activation = new Gtk.Switch();
+    this.field_keybinding_activation.connect(
+      'notify::active',
+      function (widget) {
+        that.field_keybinding.set_sensitive(widget.active);
+      },
+    );
 
-        let sizeLabel     = new Gtk.Label({
-            label: _("History Size"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let intervalLabel = new Gtk.Label({
-            label: _("Refresh Interval (ms)"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let previewLabel  = new Gtk.Label({
-            label: _("Preview Size (characters)"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let cacheSizeLabel  = new Gtk.Label({
-            label: _("Max cache file size (kb)"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let cacheDisableLabel  = new Gtk.Label({
-            label: _("Cache only favorites"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let notificationLabel  = new Gtk.Label({
-            label: _("Show notification on copy"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let confirmClearLabel = new Gtk.Label({
-            label: _("Show confirmation on Clear History"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let moveFirstLabel  = new Gtk.Label({
-            label: _("Move item to the top after selection"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let keybindingLabel  = new Gtk.Label({
-            label: _("Keyboard shortcuts"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let topbarPreviewLabel  = new Gtk.Label({
-            label: _("Number of characters in top bar"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let displayModeLabel  = new Gtk.Label({
-            label: _("What to show in top bar"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let disableDownArrowLabel = new Gtk.Label({
-            label: _("Remove down arrow in top bar"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
-        let stripTextLabel = new Gtk.Label({
-            label: _("Remove whitespace around text"),
-            hexpand: true,
-            halign: Gtk.Align.START
-        });
+    let sizeLabel = new Gtk.Label({
+      label: _('History Size'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let intervalLabel = new Gtk.Label({
+      label: _('Refresh Interval (ms)'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let previewLabel = new Gtk.Label({
+      label: _('Preview Size (characters)'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let cacheSizeLabel = new Gtk.Label({
+      label: _('Max cache file size (kb)'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let cacheDisableLabel = new Gtk.Label({
+      label: _('Cache only favorites'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let notificationLabel = new Gtk.Label({
+      label: _('Show notification on copy'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let confirmClearLabel = new Gtk.Label({
+      label: _('Show confirmation on Clear History'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let moveFirstLabel = new Gtk.Label({
+      label: _('Move item to the top after selection'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let keybindingLabel = new Gtk.Label({
+      label: _('Keyboard shortcuts'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let topbarPreviewLabel = new Gtk.Label({
+      label: _('Number of characters in top bar'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let displayModeLabel = new Gtk.Label({
+      label: _('What to show in top bar'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let disableDownArrowLabel = new Gtk.Label({
+      label: _('Remove down arrow in top bar'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let stripTextLabel = new Gtk.Label({
+      label: _('Remove whitespace around text'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
 
-        const addRow = ((main) => {
-            let row = 0;
-            return (label, input) => {
-                let inputWidget = input;
+    const addRow = ((main) => {
+      let row = 0;
+      return (label, input) => {
+        let inputWidget = input;
 
-                if (input instanceof Gtk.Switch) {
-                    inputWidget = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL,});
-                    inputWidget.append(input);
-                }
-
-                if (label) {
-                    main.attach(label, 0, row, 1, 1);
-                    main.attach(inputWidget, 1, row, 1, 1);
-                }
-                else {
-                    main.attach(inputWidget, 0, row, 2, 1);
-                }
-
-                row++;
-            };
-        })(this.main);
-
-        addRow(sizeLabel,             this.field_size);
-        addRow(previewLabel,          this.field_preview_size);
-        addRow(intervalLabel,         this.field_interval);
-        addRow(cacheSizeLabel,        this.field_cache_size);
-        addRow(cacheDisableLabel,     this.field_cache_disable);
-        addRow(notificationLabel,     this.field_notification_toggle);
-        addRow(confirmClearLabel,     this.field_confirm_clear_toggle);
-        addRow(displayModeLabel,      this.field_display_mode);
-        addRow(disableDownArrowLabel, this.field_disable_down_arrow);
-        addRow(topbarPreviewLabel,    this.field_topbar_preview_size);
-        addRow(stripTextLabel,        this.field_strip_text);
-        addRow(moveFirstLabel,        this.field_move_item_first);
-        addRow(keybindingLabel,       this.field_keybinding_activation);
-        addRow(null,                  this.field_keybinding);
-
-        SettingsSchema.bind(Fields.INTERVAL, this.field_interval, 'value', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.HISTORY_SIZE, this.field_size, 'value', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.PREVIEW_SIZE, this.field_preview_size, 'value', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.CACHE_FILE_SIZE, this.field_cache_size, 'value', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.CACHE_ONLY_FAVORITE, this.field_cache_disable, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.NOTIFY_ON_COPY, this.field_notification_toggle, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.CONFIRM_ON_CLEAR, this.field_confirm_clear_toggle, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.MOVE_ITEM_FIRST, this.field_move_item_first, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.TOPBAR_DISPLAY_MODE_ID, this.field_display_mode, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.DISABLE_DOWN_ARROW, this.field_disable_down_arrow, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.TOPBAR_PREVIEW_SIZE, this.field_topbar_preview_size, 'value', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.STRIP_TEXT, this.field_strip_text, 'active', Gio.SettingsBindFlags.DEFAULT);
-        SettingsSchema.bind(Fields.ENABLE_KEYBINDING, this.field_keybinding_activation, 'active', Gio.SettingsBindFlags.DEFAULT);
-    },
-    _create_display_mode_options : function(){
-        let options = [{ name: _("Icon") },
-        { name: _("Clipboard Content"),},
-        { name: _("Both")}];
-        let liststore = new Gtk.ListStore();
-        liststore.set_column_types([GObject.TYPE_STRING])
-        for (let i = 0; i < options.length; i++ ) {
-            let option = options[i];
-            let iter = liststore.append();
-            liststore.set (iter, [0], [option.name]);
+        if (input instanceof Gtk.Switch) {
+          inputWidget = new Gtk.Box({
+            orientation: Gtk.Orientation.HORIZONTAL,
+          });
+          inputWidget.append(input);
         }
-        return liststore;
+
+        if (label) {
+          main.attach(label, 0, row, 1, 1);
+          main.attach(inputWidget, 1, row, 1, 1);
+        } else {
+          main.attach(inputWidget, 0, row, 2, 1);
+        }
+
+        row++;
+      };
+    })(this.main);
+
+    addRow(sizeLabel, this.field_size);
+    addRow(previewLabel, this.field_preview_size);
+    addRow(intervalLabel, this.field_interval);
+    addRow(cacheSizeLabel, this.field_cache_size);
+    addRow(cacheDisableLabel, this.field_cache_disable);
+    addRow(notificationLabel, this.field_notification_toggle);
+    addRow(confirmClearLabel, this.field_confirm_clear_toggle);
+    addRow(displayModeLabel, this.field_display_mode);
+    addRow(disableDownArrowLabel, this.field_disable_down_arrow);
+    addRow(topbarPreviewLabel, this.field_topbar_preview_size);
+    addRow(stripTextLabel, this.field_strip_text);
+    addRow(moveFirstLabel, this.field_move_item_first);
+    addRow(keybindingLabel, this.field_keybinding_activation);
+    addRow(null, this.field_keybinding);
+
+    SettingsSchema.bind(
+      Fields.INTERVAL,
+      this.field_interval,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.HISTORY_SIZE,
+      this.field_size,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.PREVIEW_SIZE,
+      this.field_preview_size,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.CACHE_FILE_SIZE,
+      this.field_cache_size,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.CACHE_ONLY_FAVORITE,
+      this.field_cache_disable,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.NOTIFY_ON_COPY,
+      this.field_notification_toggle,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.CONFIRM_ON_CLEAR,
+      this.field_confirm_clear_toggle,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.MOVE_ITEM_FIRST,
+      this.field_move_item_first,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.TOPBAR_DISPLAY_MODE_ID,
+      this.field_display_mode,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.DISABLE_DOWN_ARROW,
+      this.field_disable_down_arrow,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.TOPBAR_PREVIEW_SIZE,
+      this.field_topbar_preview_size,
+      'value',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.STRIP_TEXT,
+      this.field_strip_text,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    SettingsSchema.bind(
+      Fields.ENABLE_KEYBINDING,
+      this.field_keybinding_activation,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+  },
+  _create_display_mode_options: function () {
+    let options = [
+      { name: _('Icon') },
+      { name: _('Clipboard Content') },
+      { name: _('Both') },
+    ];
+    let liststore = new Gtk.ListStore();
+    liststore.set_column_types([GObject.TYPE_STRING]);
+    for (let i = 0; i < options.length; i++) {
+      let option = options[i];
+      let iter = liststore.append();
+      liststore.set(iter, [0], [option.name]);
     }
+    return liststore;
+  },
 });
 
-function buildPrefsWidget(){
-    let widget = new App();
-    return widget.main;
+function buildPrefsWidget() {
+  let widget = new App();
+  return widget.main;
 }
-
 
 //binding widgets
 //////////////////////////////////
-const COLUMN_ID          = 0;
+const COLUMN_ID = 0;
 const COLUMN_DESCRIPTION = 1;
-const COLUMN_KEY         = 2;
-const COLUMN_MODS        = 3;
-
+const COLUMN_KEY = 2;
+const COLUMN_MODS = 3;
 
 function addKeybinding(model, settings, id, description) {
-    // Get the current accelerator.
-    let accelerator = settings.get_strv(id)[0];
-    let key, mods;
-    if (accelerator == null)
-        [key, mods] = [0, 0];
-    else
-        [,key, mods] = Gtk.accelerator_parse(settings.get_strv(id)[0]);
+  // Get the current accelerator.
+  let accelerator = settings.get_strv(id)[0];
+  let key, mods;
+  if (accelerator == null) {
+    [key, mods] = [0, 0];
+  } else {
+    [, key, mods] = Gtk.accelerator_parse(settings.get_strv(id)[0]);
+  }
 
-    // Add a row for the keybinding.
-    let row = model.insert(100); // Erm...
-    model.set(row,
-            [COLUMN_ID, COLUMN_DESCRIPTION, COLUMN_KEY, COLUMN_MODS],
-            [id,        description,        key,        mods]);
+  // Add a row for the keybinding.
+  let row = model.insert(100); // Erm...
+  model.set(
+    row,
+    [COLUMN_ID, COLUMN_DESCRIPTION, COLUMN_KEY, COLUMN_MODS],
+    [id, description, key, mods],
+  );
 }
 
 function createKeybindingWidget(SettingsSchema) {
-    let model = new Gtk.ListStore();
+  let model = new Gtk.ListStore();
 
-    model.set_column_types(
-            [GObject.TYPE_STRING, // COLUMN_ID
-             GObject.TYPE_STRING, // COLUMN_DESCRIPTION
-             GObject.TYPE_INT,    // COLUMN_KEY
-             GObject.TYPE_INT]);  // COLUMN_MODS
+  model.set_column_types([
+    GObject.TYPE_STRING, // COLUMN_ID
+    GObject.TYPE_STRING, // COLUMN_DESCRIPTION
+    GObject.TYPE_INT, // COLUMN_KEY
+    GObject.TYPE_INT,
+  ]); // COLUMN_MODS
 
-    let treeView = new Gtk.TreeView();
-    treeView.model = model;
-    treeView.headers_visible = false;
+  let treeView = new Gtk.TreeView();
+  treeView.model = model;
+  treeView.headers_visible = false;
 
-    let column, renderer;
+  let column, renderer;
 
-    // Description column.
-    renderer = new Gtk.CellRendererText();
+  // Description column.
+  renderer = new Gtk.CellRendererText();
 
-    column = new Gtk.TreeViewColumn();
-    column.expand = true;
-    column.pack_start(renderer, true);
-    column.add_attribute(renderer, "text", COLUMN_DESCRIPTION);
+  column = new Gtk.TreeViewColumn();
+  column.expand = true;
+  column.pack_start(renderer, true);
+  column.add_attribute(renderer, 'text', COLUMN_DESCRIPTION);
 
-    treeView.append_column(column);
+  treeView.append_column(column);
 
-    // Key binding column.
-    renderer = new Gtk.CellRendererAccel();
-    renderer.accel_mode = Gtk.CellRendererAccelMode.GTK;
-    renderer.editable = true;
+  // Key binding column.
+  renderer = new Gtk.CellRendererAccel();
+  renderer.accel_mode = Gtk.CellRendererAccelMode.GTK;
+  renderer.editable = true;
 
-    renderer.connect("accel-edited",
-            function (renderer, path, key, mods, hwCode) {
-                let [ok, iter] = model.get_iter_from_string(path);
-                if(!ok)
-                    return;
+  renderer.connect(
+    'accel-edited',
+    function (renderer, path, key, mods, hwCode) {
+      let [ok, iter] = model.get_iter_from_string(path);
+      if (!ok) {
+        return;
+      }
 
-                // Update the UI.
-                model.set(iter, [COLUMN_KEY, COLUMN_MODS], [key, mods]);
+      // Update the UI.
+      model.set(iter, [COLUMN_KEY, COLUMN_MODS], [key, mods]);
 
-                // Update the stored setting.
-                let id = model.get_value(iter, COLUMN_ID);
-                let accelString = Gtk.accelerator_name(key, mods);
-                SettingsSchema.set_strv(id, [accelString]);
-            });
+      // Update the stored setting.
+      let id = model.get_value(iter, COLUMN_ID);
+      let accelString = Gtk.accelerator_name(key, mods);
+      SettingsSchema.set_strv(id, [accelString]);
+    },
+  );
 
-    renderer.connect("accel-cleared",
-            function (renderer, path) {
-                let [ok, iter] = model.get_iter_from_string(path);
-                if(!ok)
-                    return;
+  renderer.connect('accel-cleared', function (renderer, path) {
+    let [ok, iter] = model.get_iter_from_string(path);
+    if (!ok) {
+      return;
+    }
 
-                // Update the UI.
-                model.set(iter, [COLUMN_KEY, COLUMN_MODS], [0, 0]);
+    // Update the UI.
+    model.set(iter, [COLUMN_KEY, COLUMN_MODS], [0, 0]);
 
-                // Update the stored setting.
-                let id = model.get_value(iter, COLUMN_ID);
-                SettingsSchema.set_strv(id, []);
-            });
+    // Update the stored setting.
+    let id = model.get_value(iter, COLUMN_ID);
+    SettingsSchema.set_strv(id, []);
+  });
 
-    column = new Gtk.TreeViewColumn();
-    column.pack_end(renderer, false);
-    column.add_attribute(renderer, "accel-key", COLUMN_KEY);
-    column.add_attribute(renderer, "accel-mods", COLUMN_MODS);
+  column = new Gtk.TreeViewColumn();
+  column.pack_end(renderer, false);
+  column.add_attribute(renderer, 'accel-key', COLUMN_KEY);
+  column.add_attribute(renderer, 'accel-mods', COLUMN_MODS);
 
-    treeView.append_column(column);
+  treeView.append_column(column);
 
-    return treeView;
+  return treeView;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,21 +1,21 @@
 .clipboard-indicator-icon.private-mode {
-    color: rgba(255,255,255,0.3);
+  color: rgba(255, 255, 255, 0.3);
 }
 
 .ci-notification-label {
-    font-weight: bold;
-    color: #ffffff;
-    background-color: rgba(10,10,10,0.7);
-    border-radius: 6px;
-    font-size:2em;
-    padding:.5em;
-    width:400px;
+  font-weight: bold;
+  color: #ffffff;
+  background-color: rgba(10, 10, 10, 0.7);
+  border-radius: 6px;
+  font-size: 2em;
+  padding: 0.5em;
+  width: 400px;
 }
 
 .popup-menu-item .ci-action-btn StIcon {
-    icon-size:16px;
+  icon-size: 16px;
 }
 
 .ci-history-menu-section {
-    max-height:450px;
+  max-height: 450px;
 }

--- a/utils.js
+++ b/utils.js
@@ -15,120 +15,132 @@ const REGISTRY_PATH = REGISTRY_DIR + '/' + REGISTRY_FILE;
 const BACKUP_REGISTRY_PATH = REGISTRY_PATH + '~';
 
 // Print objects... why no dev tools
-function prettyPrint (name, obj, recurse, _indent) {
-    let prefix = '';
-    let indent = typeof _indent === 'number' ? _indent : 0;
-    for (let i = 0; i < indent; i++) {
-        prefix += '    ';
-    }
+function prettyPrint(name, obj, recurse, _indent) {
+  let prefix = '';
+  let indent = typeof _indent === 'number' ? _indent : 0;
+  for (let i = 0; i < indent; i++) {
+    prefix += '    ';
+  }
 
-    recurse = typeof recurse === 'boolean' ? recurse : true;
-    if (typeof name !== 'string') {
-        obj = arguments[0];
-        recurse = arguments[1];
-        _indent = arguments[2];
-        name = obj.toString();
-    }
+  recurse = typeof recurse === 'boolean' ? recurse : true;
+  if (typeof name !== 'string') {
+    obj = arguments[0];
+    recurse = arguments[1];
+    _indent = arguments[2];
+    name = obj.toString();
+  }
 
-    log(prefix + '--------------');
-    log(prefix + name);
-    log(prefix + '--------------');
-    for (let k in obj) {
-        if (typeof obj[k] === 'object' && recurse) {
-            prettyPrint(name + '::' + k, obj[k], true, indent + 1);
-        }
-        else {
-            log(prefix + k, typeof obj[k] === 'function' ? '[Func]' : obj[k]);
-        }
+  log(prefix + '--------------');
+  log(prefix + name);
+  log(prefix + '--------------');
+  for (let k in obj) {
+    if (typeof obj[k] === 'object' && recurse) {
+      prettyPrint(name + '::' + k, obj[k], true, indent + 1);
+    } else {
+      log(prefix + k, typeof obj[k] === 'function' ? '[Func]' : obj[k]);
     }
+  }
 }
 
 // I/O Files
-function writeRegistry (registry) {
-    let json = JSON.stringify(registry);
-    let contents = new GLib.Bytes(json);
+function writeRegistry(registry) {
+  let json = JSON.stringify(registry);
+  let contents = new GLib.Bytes(json);
 
-    // Make sure dir exists
-    GLib.mkdir_with_parents(REGISTRY_DIR, parseInt('0775', 8));
+  // Make sure dir exists
+  GLib.mkdir_with_parents(REGISTRY_DIR, parseInt('0775', 8));
 
-    // Write contents to file asynchronously
-    let file = Gio.file_new_for_path(REGISTRY_PATH);
-    file.replace_async(null, false, Gio.FileCreateFlags.NONE,
-                        GLib.PRIORITY_DEFAULT, null, function (obj, res) {
+  // Write contents to file asynchronously
+  let file = Gio.file_new_for_path(REGISTRY_PATH);
+  file.replace_async(
+    null,
+    false,
+    Gio.FileCreateFlags.NONE,
+    GLib.PRIORITY_DEFAULT,
+    null,
+    function (obj, res) {
+      let stream = obj.replace_finish(res);
 
-        let stream = obj.replace_finish(res);
-
-        stream.write_bytes_async(contents, GLib.PRIORITY_DEFAULT,
-                            null, function (w_obj, w_res) {
-
-            w_obj.write_bytes_finish(w_res);
-            stream.close(null);
-        });
-    });
+      stream.write_bytes_async(
+        contents,
+        GLib.PRIORITY_DEFAULT,
+        null,
+        function (w_obj, w_res) {
+          w_obj.write_bytes_finish(w_res);
+          stream.close(null);
+        },
+      );
+    },
+  );
 }
 
-function readRegistry (callback) {
-    if (typeof callback !== 'function')
-        throw TypeError('`callback` must be a function');
+function readRegistry(callback) {
+  if (typeof callback !== 'function') {
+    throw TypeError('`callback` must be a function');
+  }
 
-    if (GLib.file_test(REGISTRY_PATH, FileTest.EXISTS)) {
-        let file = Gio.file_new_for_path(REGISTRY_PATH);
-        let CACHE_FILE_SIZE = SettingsSchema.get_int(Prefs.Fields.CACHE_FILE_SIZE);
+  if (GLib.file_test(REGISTRY_PATH, FileTest.EXISTS)) {
+    let file = Gio.file_new_for_path(REGISTRY_PATH);
+    let CACHE_FILE_SIZE = SettingsSchema.get_int(Prefs.Fields.CACHE_FILE_SIZE);
 
-        file.query_info_async('*', FileQueryInfoFlags.NONE,
-                              GLib.PRIORITY_DEFAULT, null, function (src, res) {
-            // Check if file size is larger than CACHE_FILE_SIZE
-            // If so, make a backup of file, and invoke callback with empty array
-            let file_info = src.query_info_finish(res);
+    file.query_info_async(
+      '*',
+      FileQueryInfoFlags.NONE,
+      GLib.PRIORITY_DEFAULT,
+      null,
+      function (src, res) {
+        // Check if file size is larger than CACHE_FILE_SIZE
+        // If so, make a backup of file, and invoke callback with empty array
+        let file_info = src.query_info_finish(res);
 
-            if (file_info.get_size() >= CACHE_FILE_SIZE * 1024) {
-                let destination = Gio.file_new_for_path(BACKUP_REGISTRY_PATH);
+        if (file_info.get_size() >= CACHE_FILE_SIZE * 1024) {
+          let destination = Gio.file_new_for_path(BACKUP_REGISTRY_PATH);
 
-                file.move(destination, FileCopyFlags.OVERWRITE, null, null);
-                callback([]);
-                return;
+          file.move(destination, FileCopyFlags.OVERWRITE, null, null);
+          callback([]);
+          return;
+        }
+
+        file.load_contents_async(null, function (obj, res) {
+          let registry;
+          let [success, contents] = obj.load_contents_finish(res);
+
+          if (success) {
+            try {
+              let max_size = SettingsSchema.get_int(Prefs.Fields.HISTORY_SIZE);
+
+              // are we running gnome 3.30 or higher?
+              if (contents instanceof Uint8Array) {
+                contents = imports.byteArray.toString(contents);
+              }
+
+              registry = JSON.parse(contents);
+
+              let registryNoFavorite = registry.filter(
+                (item) => item['favorite'] === false,
+              );
+
+              while (registryNoFavorite.length > max_size) {
+                let oldestNoFavorite = registryNoFavorite.shift();
+                let itemIdx = registry.indexOf(oldestNoFavorite);
+                registry.splice(itemIdx, 1);
+
+                registryNoFavorite = registry.filter(
+                  (item) => item['favorite'] === false,
+                );
+              }
+            } catch (e) {
+              registry = [];
             }
+          } else {
+            registry = [];
+          }
 
-            file.load_contents_async(null, function (obj, res) {
-                let registry;
-                let [success, contents] = obj.load_contents_finish(res);
-
-                if (success) {
-                    try {
-                        let max_size = SettingsSchema.get_int(Prefs.Fields.HISTORY_SIZE);
-
-                        // are we running gnome 3.30 or higher?
-                        if (contents instanceof Uint8Array) {
-                          contents = imports.byteArray.toString(contents);
-                        }
-
-                        registry = JSON.parse(contents);
-
-                        let registryNoFavorite = registry.filter(
-                            item => item['favorite'] === false);
-
-                        while (registryNoFavorite.length > max_size) {
-                            let oldestNoFavorite = registryNoFavorite.shift();
-                            let itemIdx = registry.indexOf(oldestNoFavorite);
-                            registry.splice(itemIdx,1);
-
-                            registryNoFavorite = registry.filter(
-                                item => item["favorite"] === false);
-                        }
-                    }
-                    catch (e) {
-                        registry = [];
-                    }
-                }
-                else {
-                    registry = [];
-                }
-
-                callback(registry);
-            });
+          callback(registry);
         });
-    }
-    else {
-        callback([]);
-    }
+      },
+    );
+  } else {
+    callback([]);
+  }
 }


### PR DESCRIPTION
This PR uses prettifier to force the codebase into a consistent style (important for readability). It also adds a GitHub Action that validates the style. You can run the linter locally with `npx prettier --write .`.

I tried to pick a style that matched your existing one, but it's not perfect. If you don't like this style, please let me know what you'd like changed and I'll figure out how to get the linter to do so.

PS: since the diff is complete garbage, I would recommend applying the following patch to your local copy, running `npx prettier --write .`, and then simply validating that what I uploaded is the same as what the linter produced on your machine.

```
Index: .gitignore
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.gitignore b/.gitignore
--- a/.gitignore	(revision 691cf1c09dc3c7e05d4ed99e03435d25efb9f278)
+++ b/.gitignore	(date 1641697110898)
@@ -1,1 +1,3 @@
 *.zip
+.idea
+node_modules/
Index: package-lock.json
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/package-lock.json b/package-lock.json
new file mode 100644
--- /dev/null	(date 1641697110890)
+++ b/package-lock.json	(date 1641697110890)
@@ -0,0 +1,32 @@
+{
+  "name": "gnome-shell-extension-clipboard-indicator",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "2.5.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    }
+  }
+}
Index: package.json
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/package.json b/package.json
new file mode 100644
--- /dev/null	(date 1641697110886)
+++ b/package.json	(date 1641697110886)
@@ -0,0 +1,5 @@
+{
+  "devDependencies": {
+    "prettier": "2.5.1"
+  }
+}
Index: .prettierrc.json
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.prettierrc.json b/.prettierrc.json
new file mode 100644
--- /dev/null	(date 1641697110882)
+++ b/.prettierrc.json	(date 1641697110882)
@@ -0,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}
Index: .github/workflows/ci.yml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
new file mode 100644
--- /dev/null	(date 1641697110862)
+++ b/.github/workflows/ci.yml	(date 1641697110862)
@@ -0,0 +1,17 @@
+name: CI/CD
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          cache: 'npm'
+      - name: Check style
+        run: npx prettier --check .
```