### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
     "shell-version": [
-        "42"
+        "42",
+        "43"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
Updated to run on Gnome 43.
Running the extension on Fedora 37 beta , no issues (so far).