### PR TITLE
Update metadata.json to run on Fedora 37

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
     "shell-version": [
         "42",
-        "43"
+        "43",
+        "43.2"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
This is my local change to make it work on Fedora 37. So I thought I will share. I do not see if that is all what is needed.