### PR TITLE
Disable notifications for "Do Not Disturb" and "Private" modes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -788,6 +788,14 @@ const ClipboardIndicator = GObject.registerClass({
     }
 
     _showNotification (message, transformFn) {
+        const dndOn = () =>
+          !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean(
+            'show-banners',
+          );
+        if (PRIVATEMODE || dndOn()) {
+          return;
+        }
+
         let notification = null;
 
         this._initNotifSource();


### PR DESCRIPTION
Simple port of [commit from the Clipboard History](https://github.com/SUPERCILEX/gnome-clipboard-history/commit/7e22dc026c73ed4a27b447529c4fae5cb6ec74c2) extension.