### PR TITLE
Truncate text based on graphemes instead of code units

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -374,8 +374,9 @@ const ClipboardIndicator = GObject.registerClass({
     _truncate (string, length) {
         let shortened = string.replace(/\s+/g, ' ');
 
-        if (shortened.length > length)
-            shortened = shortened.substring(0,length-1) + '...';
+        let chars = [...shortened]
+        if (chars.length > length)
+            shortened = chars.slice(0, length - 1).join('') + '...';
 
         return shortened;
     }


### PR DESCRIPTION
Fixes #404.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length#strings_with_length_not_equal_to_the_number_of_characters