### PR TITLE
Fix Extra Spacing In All Gnome Shell Menus

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -12,9 +12,10 @@
     width:400px;
 }
 
-.popup-menu-item {
-    margin: 0 .8em;
+.ci-history-menu-section .popup-menu-item {
+    margin-right: .8em;
 }
+
 .popup-menu-item .ci-action-btn StIcon {
     icon-size:1.2em;
     margin-left:.25em;


### PR DESCRIPTION
This fixes the extra spacing/margins added to menu items in all gnome panel menus bug mentioned in issue #483. The CSS was too general, so it targeted all gnome panel menu items.

 It also removed unneeded left space added to clipboard history menu items since only a right margin was needed.

**Before:**
![image](https://github.com/user-attachments/assets/b1118fd6-1749-4dc5-a60e-e4dee1fa8d3e)
![image](https://github.com/user-attachments/assets/8ed1a270-c2db-4168-a423-4a53aa20fc73)


**After:** 
![image](https://github.com/user-attachments/assets/3093ba90-d1da-4774-8f21-94d1626357ba)
![image](https://github.com/user-attachments/assets/c5f869c0-9c5e-46d0-9ff1-172cf491f276)
