### PR TITLE
Fix icon being offcenter

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -986,11 +986,13 @@ const ClipboardIndicator = GObject.registerClass({
         if(TOPBAR_DISPLAY_MODE === 0){
             this.icon.visible = true;
             this._buttonText.visible = false;
+            this._buttonImgPreview.visible = false;
             this.show();
         }
         if(TOPBAR_DISPLAY_MODE === 1){
             this.icon.visible = false;
             this._buttonText.visible = true;
+            this._buttonImgPreview.visible = false;
             this.show();
         }
         if(TOPBAR_DISPLAY_MODE === 2){

--- a/extension.js
+++ b/extension.js
@@ -992,12 +992,13 @@ const ClipboardIndicator = GObject.registerClass({
         if(TOPBAR_DISPLAY_MODE === 1){
             this.icon.visible = false;
             this._buttonText.visible = true;
-            this._buttonImgPreview.visible = false;
+            this._buttonImgPreview.visible = true;
             this.show();
         }
         if(TOPBAR_DISPLAY_MODE === 2){
             this.icon.visible = true;
             this._buttonText.visible = true;
+            this._buttonImgPreview.visible = true;
             this.show();
         }
         if (TOPBAR_DISPLAY_MODE === 3) {


### PR DESCRIPTION
This fixes #490.

The issue was that the buttonImgPreview wasnt being hidden even when having only show icon in settings enabled. This way altough it didnt show any images, as some other code handled that, it still took space, moving the icon.

_I think the preview is still not complety in the center, but thats due to the fact, that the size of the icon and the size of the tray box dont match, e.g. box is 5 px and the preview is 2 px, so there is no way to completely center the preview._