### PR TITLE
Handle the empty registry cache file

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -89,7 +89,15 @@ export class Registry {
 
                         if (success) {
                             let max_size = this.settings.get_int(PrefsFields.HISTORY_SIZE);
-                            const registry = JSON.parse(new TextDecoder().decode(contents));
+                            const cacheTextData = new TextDecoder().decode(contents);
+                            var registry;
+                            if (cacheTextData.trim().length == 0) {
+                                // console.log('Clipboard Indicator: returning [] due to empty registry file');
+                                registry = [];
+                            } else {
+                                // console.log('Clipboard Indicator: work after returning [] due to empty registry file');
+                                registry = JSON.parse(cacheTextData);
+                            }
                             const entriesPromises = registry.map(
                                 jsonEntry => {
                                     return ClipboardEntry.fromJSON(jsonEntry)


### PR DESCRIPTION
I ran into the same issue as described in #502. In my case, the `JS ERROR: SyntaxError: JSON.parse: unexpected end of data at line 1 column 1` was caused by an empty registry file (registry.txt).

Unfortunately, the issue appears to have started quite some time ago (likely in the second half of 2024). I postponed  investigating why the extension stopped working until this week, and by now I can no longer determine what originally caused the registry file to be emptied.