### PR TITLE
Add gnome 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
         "46",
         "47",
         "48",
-        "49"
+        "49",
+        "50"
     ],
     "uuid": "clipboard-indicator@tudmotu.com",
     "name": "Clipboard Indicator",


### PR DESCRIPTION
Add gnome 50 in supported shell versions, no other changes needed according to my testing so far on Ubuntu 26.04 