### PR TITLE
fix:"move the item to the top after selection" not effective when ena…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -969,8 +969,19 @@ const ClipboardIndicator = GObject.registerClass({
         }
 
         // Ensure MOVE_ITEM_FIRST also applies when PASTE_ON_SELECT fast-path skips _refreshIndicator()
-        if (PASTE_ON_SELECT && MOVE_ITEM_FIRST && !menuItem.entry.isFavorite()) {
+        if (!menuItem.entry.isFavorite() && MOVE_ITEM_FIRST) {
+            this._skipMoveInRefresh = true;
             this._moveItemFirst(menuItem);
+
+            // #pasteItem sets preventIndicatorUpdate which blocks the
+            // indicator refresh inside _addEntry → _selectMenuItem, so
+            // force an update here to keep the panel in sync.
+            if (this.preventIndicatorUpdate) {
+                const saved = this.preventIndicatorUpdate;
+                this.preventIndicatorUpdate = false;
+                this.#updateIndicatorContent(menuItem.entry);
+                this.preventIndicatorUpdate = saved;
+            }
         }
 
         menuItem.menu.close();
@@ -1025,7 +1036,11 @@ const ClipboardIndicator = GObject.registerClass({
                         this._selectMenuItem(menuItem, false);
 
                         if (!menuItem.entry.isFavorite() && MOVE_ITEM_FIRST) {
-                            this._moveItemFirst(menuItem);
+                            if (this._skipMoveInRefresh) {
+                                this._skipMoveInRefresh = false;
+                            } else {
+                                this._moveItemFirst(menuItem);
+                            }
                         }
 
                         return;
@@ -1648,8 +1663,6 @@ const ClipboardIndicator = GObject.registerClass({
 
             this._pastingResetTimeout = setTimeout(() => {
                 this.preventIndicatorUpdate = false;
-                if (currentlySelected && currentlySelected.entry)
-                    this.#updateClipboard(currentlySelected.entry);
             }, 50);
         }, 50);
     }

--- a/extension.js
+++ b/extension.js
@@ -972,16 +972,17 @@ const ClipboardIndicator = GObject.registerClass({
         if (!menuItem.entry.isFavorite() && MOVE_ITEM_FIRST) {
             this._skipMoveInRefresh = true;
             this._moveItemFirst(menuItem);
+        }
 
-            // #pasteItem sets preventIndicatorUpdate which blocks the
-            // indicator refresh inside _addEntry → _selectMenuItem, so
-            // force an update here to keep the panel in sync.
-            if (this.preventIndicatorUpdate) {
-                const saved = this.preventIndicatorUpdate;
-                this.preventIndicatorUpdate = false;
-                this.#updateIndicatorContent(menuItem.entry);
-                this.preventIndicatorUpdate = saved;
-            }
+        // #pasteItem sets preventIndicatorUpdate which blocks the
+        // indicator refresh inside _addEntry → _selectMenuItem, so
+        // force an update here to keep the panel in sync with the
+        // selected item (regardless of whether MOVE_ITEM_FIRST is on).
+        if (this.preventIndicatorUpdate) {
+            const saved = this.preventIndicatorUpdate;
+            this.preventIndicatorUpdate = false;
+            this.#updateIndicatorContent(menuItem.entry);
+            this.preventIndicatorUpdate = saved;
         }
 
         menuItem.menu.close();


### PR DESCRIPTION
**Closes #613 , #559**

## Description

When both **"Paste on Select"** and **"Move item first"** options are enabled, clicking any non-first entry causes it to move to the **second line** of the clipboard history list, instead of the expected first position.

### Root Cause

The bug results from three interconnected issues:

1. **Duplicate `_moveItemFirst` calls**: `_onMenuItemSelectedAndMenuClose` moves the item to the top first. Then `_refreshIndicator` is triggered by clipboard changes and tries to move the same item again — but by this time the `menuItem` has already been destroyed and recreated by the first move, causing the second move to effectively restore the old selected item to the top.

2. **Unnecessary clipboard restoration in `#pasteItem`**: After pasting completes, `_pastingResetTimeout` restores the clipboard content back to the old `currentlySelected` entry. This triggers an extra `_refreshIndicator` call, which in turn triggers the duplicate move described above.

3. **Conditional guard missing non-paste scenarios**: `MOVE_ITEM_FIRST` in `_onMenuItemSelectedAndMenuClose` was wrapped inside a `PASTE_ON_SELECT` check, so the "move first" behavior didn't apply to normal Enter-key selections.

### Changes Made

1. **`_onMenuItemSelectedAndMenuClose`**: Removed the `PASTE_ON_SELECT` check; sets `_skipMoveInRefresh = true` before `_moveItemFirst`; forces indicator content sync when `preventIndicatorUpdate` is active. 
2. **`_refreshIndicator`**: Checks the `_skipMoveInRefresh` flag — if `_onMenuItemSelectedAndMenuClose` already moved the item, skip the redundant move and just clear the flag. 
3.  **`#pasteItem`**: Removed the clipboard restoration logic (`this.#updateClipboard(currentlySelected.entry)`) in `_pastingResetTimeout`, eliminating the unnecessary `_refreshIndicator` trigger. 

### Result

With "Paste on Select" + "Move item first" enabled, clicking any non-first entry correctly places it at the top and the top-bar indicator will sync after paste operations

### Verified version
- fedora43@Gnome49
<img width="480" height="385" alt="录屏 2026-05-17 00-44-35" src="https://github.com/user-attachments/assets/fb4cd753-4a85-4f4a-ae72-4cf5663a8b60" />
