### PR TITLE
Fix memory bloat, crash on corrupt cache, and 3 bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Clipboard Indicator is a GNOME Shell extension (UUID: `clipboard-indicator@tudmotu.com`) that provides clipboard history management. It targets GNOME 46-50 and uses GJS (GNOME JavaScript) with GObject Introspection bindings (`gi://` imports). There is no npm, no bundler, no transpilation — files are loaded directly by GNOME Shell.
+
+## Build & Development Commands
+
+```bash
+# Compile GSettings schemas and locale .mo files (required after schema or translation changes)
+make
+
+# Install to ~/.local/share/gnome-shell/extensions/clipboard-indicator@tudmotu.com/
+make install
+
+# Build distributable zip for extensions.gnome.org
+make bundle
+
+# Update .pot and merge into existing .po translation files
+make update-po-files
+
+# Launch a nested GNOME Shell session for testing (Wayland, 2048x1536@2x)
+make nested-session
+```
+
+After `make install`, restart GNOME Shell (log out/in on Wayland, or Alt+F2 `r` on X11) and enable with:
+```bash
+gnome-extensions enable clipboard-indicator@tudmotu.com
+```
+
+There is no test suite or linter configured.
+
+## Architecture
+
+The extension is a flat set of ES modules — no subdirectories for source code.
+
+### Module Responsibilities
+
+- **`extension.js`** (~1970 lines) — The main module. Exports `ClipboardIndicatorExtension` (lifecycle: `enable`/`disable`) which creates a `ClipboardIndicator` GObject class extending `PanelMenu.Button`. Contains all UI construction (panel button, popup menu, search bar, history sections, favorites section, action buttons), clipboard monitoring via `Meta.Selection`, keyboard shortcut binding, settings synchronization, private mode, app exclusion, image preview overlay, tag/edit dialogs, interval-based history clearing, and paste simulation via virtual keyboard.
+
+- **`registry.js`** — Persistence layer. `Registry` reads/writes clipboard history to `~/.cache/clipboard-indicator@tudmotu.com/registry.txt` as JSON. Handles image file caching (stored as hashed filenames in the same cache dir). `ClipboardEntry` models a single clipboard item with mimetype, bytes, favorite flag, and optional tag. Supports text and image entries.
+
+- **`prefs.js`** (~710 lines) — Preferences window using libadwaita (`Adw.PreferencesWindow`). Organized into tabbed pages (UI, Behavior, Search, Limits, Exclusion, Topbar, Notifications, Shortcuts). Loaded by GNOME in a separate process from the extension.
+
+- **`constants.js`** — Maps `PrefsFields` enum to GSettings key names. Single source of truth for settings key strings used by both `extension.js` and `prefs.js`.
+
+- **`confirmDialog.js`** — `DialogManager` wraps a `ModalDialog` for confirmation prompts (clear history, delete pinned items). Ensures only one dialog at a time.
+
+- **`keyboard.js`** — `Keyboard` class wraps a Clutter virtual keyboard device for simulating paste keystrokes (Shift+Insert for normal apps, Ctrl+Shift+Insert for terminals).
+
+- **`stylesheet.css`** — All CSS classes prefixed with `ci-` or `clipboard-indicator-`/`clipboard-menu-`.
+
+### Settings
+
+All preferences are defined in `schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml`. After modifying this file, run `make compile-settings` (or just `make`). The compiled binary `schemas/gschemas.compiled` is checked into the repo.
+
+### Translations
+
+25 locales under `locale/*/LC_MESSAGES/`. The `.pot` template is `clipboard-indicator.pot`. After adding new translatable strings (wrapped in `_()` or `N_()`), run `make update-po-files`.
+
+## Key Patterns
+
+- **GObject registration**: The `ClipboardIndicator` class uses `GObject.registerClass` with a `GTypeName`. It follows GNOME Shell's `_init` convention (not a standard constructor).
+- **Settings flow**: Module-level `let` variables (e.g., `MAX_REGISTRY_LENGTH`, `PRIVATEMODE`) are synced from GSettings in `_loadSettings()` and updated via `settings.connect('changed')`. These are effectively global state within the extension.
+- **Clipboard monitoring**: Uses `global.display.get_selection().connect('owner-changed')` to detect clipboard changes, then reads content via `St.Clipboard`.
+- **Private fields**: Uses JS private class fields (`#field`) extensively in `ClipboardIndicator`, `Registry`, `ClipboardEntry`, `DialogManager`, and `Keyboard`.
+- **Async I/O**: Registry file operations use GIO async methods (`replace_async`, `load_contents_async`) wrapped in Promises.
+
+## Contributing Guidelines (from upstream)
+
+- Do not open unsolicited PRs — look for "Up for grabs" issues first.
+- Discuss features in issues before implementing.
+- Release cycle follows GNOME's (~2 updates/year around GNOME major releases).
+- Translation PRs are always welcome without prior discussion.

--- a/extension.js
+++ b/extension.js
@@ -1636,11 +1636,12 @@ const ClipboardIndicator = GObject.registerClass({
 
 
 
-    #pasteItem (menuItem) {
+    async #pasteItem (menuItem) {
         this.menu.close();
         const currentlySelected = this._getCurrentlySelectedItem();
+        const shouldRestore = !PASTE_ON_SELECT && currentlySelected && currentlySelected !== menuItem;
         this.preventIndicatorUpdate = true;
-        this.#updateClipboard(menuItem.entry);
+        await this.#updateClipboard(menuItem.entry);
         this._pastingKeypressTimeout = setTimeout(() => {
             if (this.keyboard.purpose === Clutter.InputContentPurpose.TERMINAL) {
                 this.keyboard.press(Clutter.KEY_Control_L);
@@ -1657,10 +1658,10 @@ const ClipboardIndicator = GObject.registerClass({
                 this.keyboard.release(Clutter.KEY_Shift_L);
             }
 
-            this._pastingResetTimeout = setTimeout(() => {
+            this._pastingResetTimeout = setTimeout(async () => {
                 this.preventIndicatorUpdate = false;
-                if (currentlySelected && currentlySelected.entry)
-                    this.#updateClipboard(currentlySelected.entry);
+                if (shouldRestore && currentlySelected.entry)
+                    await this.#updateClipboard(currentlySelected.entry);
             }, 50);
         }, 50);
     }

--- a/extension.js
+++ b/extension.js
@@ -406,6 +406,12 @@ const ClipboardIndicator = GObject.registerClass({
             this._selectMenuItem(clipItemsArr[lastIdx]);
         }
 
+        // Clean up orphaned image files in the cache directory
+        const referencedPaths = new Set(
+            clipHistory.filter(e => e.isImage() && e.getFilePath()).map(e => e.getFilePath())
+        );
+        this.registry.cleanOrphanedFiles(referencedPaths);
+
         this.#showElements();
     }
 
@@ -926,7 +932,7 @@ const ClipboardIndicator = GObject.registerClass({
         }
     }
 
-    _onMenuItemSelected (menuItem, autoSet) {
+    async _onMenuItemSelected (menuItem, autoSet) {
         for (let otherMenuItem of menuItem.radioGroup) {
             let clipContents = menuItem.clipContents;
 
@@ -935,7 +941,7 @@ const ClipboardIndicator = GObject.registerClass({
                 if (menuItem._ornamentIcon) menuItem._ornamentIcon.opacity = 255;
                 menuItem.currentlySelected = true;
                 if (autoSet !== false)
-                    this.#updateClipboard(menuItem.entry);
+                    await this.#updateClipboard(menuItem.entry);
             }
             else {
                 otherMenuItem.setOrnament(PopupMenu.Ornament.DOT);
@@ -945,12 +951,12 @@ const ClipboardIndicator = GObject.registerClass({
         }
     }
 
-    _selectMenuItem (menuItem, autoSet) {
-        this._onMenuItemSelected(menuItem, autoSet);
+    async _selectMenuItem (menuItem, autoSet) {
+        await this._onMenuItemSelected(menuItem, autoSet);
         this.#updateIndicatorContent(menuItem.entry);
     }
 
-    _onMenuItemSelectedAndMenuClose (menuItem, autoSet) {
+    async _onMenuItemSelectedAndMenuClose (menuItem, autoSet) {
         for (let otherMenuItem of menuItem.radioGroup) {
             let clipContents = menuItem.clipContents;
 
@@ -959,7 +965,7 @@ const ClipboardIndicator = GObject.registerClass({
                 if (menuItem._ornamentIcon) menuItem._ornamentIcon.opacity = 255;
                 menuItem.currentlySelected = true;
                 if (autoSet !== false)
-                    this.#updateClipboard(menuItem.entry);
+                    await this.#updateClipboard(menuItem.entry);
             }
             else {
                 otherMenuItem.setOrnament(PopupMenu.Ornament.DOT);
@@ -1234,7 +1240,12 @@ const ClipboardIndicator = GObject.registerClass({
     }
 
     _openSettings () {
-        this.extension.openSettings();
+        try {
+            const result = this.extension.openSettings();
+            if (result?.catch) result.catch(e => console.error(e));
+        } catch (e) {
+            console.error(e);
+        }
         this.menu.close();
     }
 
@@ -1555,8 +1566,8 @@ const ClipboardIndicator = GObject.registerClass({
     _selectEntryWithDelay (entry) {
         this._selectMenuItem(entry, false);
 
-        this._delayedSelectionTimeoutId = setTimeout(() => {
-            this._selectMenuItem(entry);  //select the item
+        this._delayedSelectionTimeoutId = setTimeout(async () => {
+            this._selectMenuItem(entry);
             this._delayedSelectionTimeoutId = null;
         }, DELAYED_SELECTION_TIMEOUT);
     }
@@ -1911,9 +1922,15 @@ const ClipboardIndicator = GObject.registerClass({
         this.#updateIndicatorContent(null);
     }
 
-    #updateClipboard (entry) {
+    async #updateClipboard (entry) {
+        if (entry.isImage() && !entry.hasBytes()) {
+            await entry.loadBytes();
+        }
         this.extension.clipboard.set_content(CLIPBOARD_TYPE, entry.mimetype(), entry.asBytes());
         this.#updateIndicatorContent(entry);
+        if (entry.isImage()) {
+            entry.releaseBytes();
+        }
     }
 
     async #getClipboardContent () {

--- a/extension.js
+++ b/extension.js
@@ -877,11 +877,8 @@ const ClipboardIndicator = GObject.registerClass({
             }
         });
 
-        if (NOTIFY_ON_CLEAR) {
-            const message = invokedAutomatically
-                ? _("Clipboard history cleared automatically")
-                : _("Clipboard history cleared");
-            this._showNotification(message);
+        if (NOTIFY_ON_CLEAR && !invokedAutomatically) {
+            this._showNotification(_("Clipboard history cleared"));
         }
     }
 

--- a/registry.js
+++ b/registry.js
@@ -34,7 +34,7 @@ export class Registry {
             else if (entry.isImage()) {
                 const filename = this.getEntryFilename(entry);
                 item.contents = filename;
-                this.writeEntryFile(entry);
+                if (entry.hasBytes()) this.writeEntryFile(entry);
             }
 
             if (entry.getTag()) item.tag = entry.getTag();
@@ -146,7 +146,8 @@ export class Registry {
     async getEntryAsImage (entry) {
         if (entry.isImage() === false) return;
 
-        if (this.#entryFileExists(entry) == false) {
+        if (this.#entryFileExists(entry) === false) {
+            if (!entry.hasBytes()) return;
             await this.writeEntryFile(entry);
         }
 
@@ -159,6 +160,7 @@ export class Registry {
         if (entry.isImage() === false) return null;
 
         if (this.#entryFileExists(entry) === false) {
+            if (!entry.hasBytes()) return null;
             await this.writeEntryFile(entry);
         }
 
@@ -168,6 +170,7 @@ export class Registry {
     }
 
     getEntryFilename (entry) {
+        if (entry.getFilePath()) return entry.getFilePath();
         return `${this.REGISTRY_DIR}/${entry.asBytes().hash()}`;
     }
 
@@ -204,18 +207,45 @@ export class Registry {
         }
     }
 
-    clearCacheFolder() {
-
-        const CANCELLABLE = null;
+    cleanOrphanedFiles (referencedPaths) {
         try {
             const folder = Gio.file_new_for_path(this.REGISTRY_DIR);
-            const enumerator = folder.enumerate_children("", 1, CANCELLABLE);
+            const enumerator = folder.enumerate_children(
+                'standard::name', FileQueryInfoFlags.NONE, null);
 
-            let file;
-            while ((file = enumerator.iterate(CANCELLABLE)[2]) != null) {
-                file.delete(CANCELLABLE);
+            let orphanCount = 0;
+            let info;
+            while ((info = enumerator.next_file(null)) !== null) {
+                const name = info.get_name();
+                if (name === this.REGISTRY_FILE || name === this.REGISTRY_FILE + '~')
+                    continue;
+
+                const filePath = `${this.REGISTRY_DIR}/${name}`;
+                if (!referencedPaths.has(filePath)) {
+                    const file = Gio.file_new_for_path(filePath);
+                    file.delete_async(GLib.PRIORITY_LOW, null, null);
+                    orphanCount++;
+                }
             }
 
+            if (orphanCount > 0) {
+                console.log(`Clipboard Indicator: removed ${orphanCount} orphaned cache file(s)`);
+            }
+        }
+        catch (e) {
+            console.error('Clipboard Indicator: failed to clean orphaned files', e);
+        }
+    }
+
+    clearCacheFolder() {
+        try {
+            const folder = Gio.file_new_for_path(this.REGISTRY_DIR);
+            const enumerator = folder.enumerate_children("", 1, null);
+
+            let file;
+            while ((file = enumerator.iterate(null)[2]) != null) {
+                file.delete(null);
+            }
         }
         catch (e) {
             console.error(e);
@@ -227,6 +257,8 @@ export class ClipboardEntry {
     #mimetype;
     #bytes;
     #favorite;
+    #filePath = null;
+    #hash = null;
 
     static #decode (contents) {
         return Uint8Array.from(contents.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
@@ -238,49 +270,29 @@ export class ClipboardEntry {
             mimetype === 'UTF8_STRING';
     }
 
+    static fromCachedImage (mimetype, filePath, favorite) {
+        const entry = new ClipboardEntry(mimetype, null, favorite);
+        entry.#filePath = filePath;
+        const parts = filePath.split('/');
+        entry.#hash = parts[parts.length - 1];
+        return entry;
+    }
+
     static async fromJSON (jsonEntry) {
         const mimetype = jsonEntry.mimetype || 'text/plain;charset=utf-8';
         const favorite = jsonEntry.favorite;
-        let bytes;
 
         if (ClipboardEntry.__isText(mimetype)) {
-            bytes = new TextEncoder().encode(jsonEntry.contents);
-        }
-        else {
-            const filename = jsonEntry.contents;
-            if (!GLib.file_test(filename, FileTest.EXISTS)) return null;
-
-            let file = Gio.file_new_for_path(filename);
-
-            const contentType = await file.query_info_async('*', FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null, (obj, res) => {
-                try {
-                    const fileInfo = obj.query_info_finish(res);
-                    return fileInfo.get_content_type();
-                } catch (e) {
-                    console.error(e);
-                }
-            });
-
-            if (contentType && !contentType.startsWith('image/') && !contentType.startsWith('text/')) {
-                bytes = new TextEncoder().encode(jsonEntry.contents);
-            }
-            else {
-                bytes = await new Promise((resolve, reject) => file.load_contents_async(null, (obj, res) => {
-                    let [success, contents] = obj.load_contents_finish(res);
-
-                    if (success) {
-                        resolve(contents);
-                    }
-                    else {
-                        reject(
-                            new Error('Clipboard Indicator: could not read image file from cache')
-                        );
-                    }
-                }));
-            }
+            const bytes = new TextEncoder().encode(jsonEntry.contents);
+            const entry = new ClipboardEntry(mimetype, bytes, favorite);
+            if (jsonEntry.tag) entry.setTag(jsonEntry.tag);
+            return entry;
         }
 
-        const entry = new ClipboardEntry(mimetype, bytes, favorite);
+        const filename = jsonEntry.contents;
+        if (!GLib.file_test(filename, FileTest.EXISTS)) return null;
+
+        const entry = ClipboardEntry.fromCachedImage(mimetype, filename, favorite);
         if (jsonEntry.tag) entry.setTag(jsonEntry.tag);
         return entry;
     }
@@ -303,6 +315,7 @@ export class ClipboardEntry {
 
     getStringValue () {
         if (this.isImage()) {
+            if (this.#hash) return `[Image ${this.#hash}]`;
             return `[Image ${this.asBytes().hash()}]`;
         }
         return new TextDecoder().decode(this.#bytes);
@@ -345,6 +358,35 @@ export class ClipboardEntry {
 
     asBytes () {
         return GLib.Bytes.new(this.#bytes);
+    }
+
+    hasBytes () {
+        return this.#bytes !== null;
+    }
+
+    async loadBytes () {
+        if (this.#bytes !== null || !this.#filePath) return;
+
+        return new Promise((resolve, reject) => {
+            const file = Gio.file_new_for_path(this.#filePath);
+            file.load_contents_async(null, (obj, res) => {
+                let [success, contents] = obj.load_contents_finish(res);
+                if (success) {
+                    this.#bytes = contents;
+                    resolve();
+                } else {
+                    reject(new Error(`Clipboard Indicator: could not load image from ${this.#filePath}`));
+                }
+            });
+        });
+    }
+
+    releaseBytes () {
+        if (this.#filePath) this.#bytes = null;
+    }
+
+    getFilePath () {
+        return this.#filePath;
     }
 
     equals (otherEntry) {

--- a/registry.js
+++ b/registry.js
@@ -96,7 +96,16 @@ export class Registry {
                             if (cacheTextData.trim().length == 0) {
                                 registry = [];
                             } else {
-                                registry = JSON.parse(cacheTextData);
+                                try {
+                                    registry = JSON.parse(cacheTextData);
+                                } catch (e) {
+                                    console.error('Clipboard Indicator: cache file contains malformed JSON, starting with empty history');
+                                    console.error(e);
+                                    let destination = Gio.file_new_for_path(this.BACKUP_REGISTRY_PATH);
+                                    file.move(destination, FileCopyFlags.OVERWRITE, null, null);
+                                    resolve([]);
+                                    return;
+                                }
                             }
                             const entriesPromises = registry.map(
                                 jsonEntry => {


### PR DESCRIPTION
## Summary

This PR addresses several open issues:

- **Lazy-load image bytes at startup**: image entries now store only a file path and hash instead of reading full bytes into memory. Bytes are loaded on demand when pasting, then released. Eliminates the startup memory spike described in #617 (hundreds of MB of images loaded into gnome-shell heap).
- **Clean orphaned cache files on startup**: unreferenced image files in `~/.cache/clipboard-indicator@tudmotu.com/` are deleted when the extension loads.
- **Handle malformed JSON in cache gracefully** (#589, #502): corrupted `registry.txt` no longer kills the extension — it backs up the bad file and starts with empty history.
- **Fix move-to-top with paste-on-select** (#613, #559): the pasted item now correctly moves to position 1 instead of position 2. Root cause was `#pasteItem` restoring the previous clipboard selection after 100ms, clobbering the `_moveItemFirst` reorder.
- **Suppress auto-clear notification** (#587): automatic interval clears no longer show a notification — only manual "Clear history" does.
- **Fix unhandled error in _openSettings**: guard against `openSettings()` returning undefined in nested sessions.

Each fix is a separate commit for cherry-picking.

## Issues closed

- Closes #617
- Closes #589
- Closes #502
- Closes #613
- Closes #559
- Closes #587

## Test plan

- [x] `make` compiles schemas and locales
- [x] Extension loads in `make nested-session` with zero JS errors
- [x] Corrupted `registry.txt` — extension logs error, backs up bad file, starts with empty history (verified in nested session)
- [x] 49 orphaned cache files removed on startup (verified in nested session)
- [x] Copy/paste text and images works
- [x] Settings button works without JS errors in nested session
- [x] "Paste on select" + "Move item to top" — selected item moves to position 1
- [x] "Clear history on interval" with notifications off — no notification on auto-clear

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>